### PR TITLE
NIAD-318: Logging Standards

### DIFF
--- a/ops/local/docker-compose.yml
+++ b/ops/local/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "10001:8080"
     environment:
       - PEM111_AMQP_BROKER=amqp://activemq:5672
+      - LOG_LEVEL=DEBUG
 
   activemq:
     image: rmohr/activemq:5.15.9

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 
 }
 
+lombok {
+    config['lombok.log.fieldName'] = 'LOGGER'
+}
+
 sourceSets {
     integrationTest {
         java {

--- a/service/src/integration-test/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportControllerIT.java
+++ b/service/src/integration-test/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportControllerIT.java
@@ -1,5 +1,21 @@
 package uk.nhs.adaptors.oneoneone.cda.report.controller;
 
+import static java.nio.file.Files.readAllBytes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpStatus.ACCEPTED;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.URL;
+import java.nio.file.Paths;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,21 +23,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import uk.nhs.adaptors.oneoneone.config.AmqpProperties;
 import uk.nhs.adaptors.oneoneone.utils.FhirJsonValidator;
-
-import javax.jms.JMSException;
-import javax.jms.Message;
-import java.net.URL;
-import java.nio.file.Paths;
-
-import static io.restassured.RestAssured.given;
-import static java.nio.file.Files.readAllBytes;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.http.HttpStatus.ACCEPTED;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -44,25 +48,25 @@ public class ReportControllerIT {
     @Test
     public void postReportInvalidBody() {
         given()
-                .port(port)
-                .contentType(APPLICATION_XML_VALUE)
-                .body("<invalid_xml>")
-                .when()
-                .post(REPORT_ENDPOINT)
-                .then()
-                .statusCode(BAD_REQUEST.value()).extract();
+            .port(port)
+            .contentType(APPLICATION_XML_VALUE)
+            .body("<invalid_xml>")
+            .when()
+            .post(REPORT_ENDPOINT)
+            .then()
+            .statusCode(BAD_REQUEST.value()).extract();
     }
 
     @Test
     public void postReportValidBody() throws JMSException {
         given()
-                .port(port)
-                .contentType(APPLICATION_XML_VALUE)
-                .body(getResourceAsString("/xml/ITK_Report_request.xml"))
-                .when()
-                .post(REPORT_ENDPOINT)
-                .then()
-                .statusCode(ACCEPTED.value());
+            .port(port)
+            .contentType(APPLICATION_XML_VALUE)
+            .body(getResourceAsString("/xml/ITK_Report_request.xml"))
+            .when()
+            .post(REPORT_ENDPOINT)
+            .then()
+            .statusCode(ACCEPTED.value());
 
         Message jmsMessage = jmsTemplate.receive(amqpProperties.getQueueName());
         String messageBody = jmsMessage.getBody(String.class);

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
@@ -1,6 +1,15 @@
 package uk.nhs.adaptors.oneoneone.cda.report.controller;
 
-import lombok.AllArgsConstructor;
+import static org.springframework.http.HttpStatus.ACCEPTED;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.springframework.http.MediaType.TEXT_XML_VALUE;
+
+import static uk.nhs.adaptors.oneoneone.cda.report.controller.utils.ReportRequestUtils.extractClinicalDocument;
+import static uk.nhs.adaptors.oneoneone.xml.XmlValidator.validate;
+
+import java.util.Map;
+
 import org.apache.xmlbeans.XmlException;
 import org.dom4j.DocumentException;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,38 +17,37 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.oneoneone.cda.report.controller.utils.ReportElement;
 import uk.nhs.adaptors.oneoneone.cda.report.controller.utils.ReportParserUtil;
 import uk.nhs.adaptors.oneoneone.cda.report.service.EncounterReportService;
 import uk.nhs.connect.iucds.cda.ucr.POCDMT000002UK01ClinicalDocument1;
 
-import java.util.Map;
-
-import static org.springframework.http.HttpStatus.ACCEPTED;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
-import static org.springframework.http.MediaType.TEXT_XML_VALUE;
-import static uk.nhs.adaptors.oneoneone.cda.report.controller.utils.ReportRequestUtils.extractClinicalDocument;
-import static uk.nhs.adaptors.oneoneone.xml.XmlValidator.validate;
-
 @RestController
 @AllArgsConstructor
+@Slf4j
 public class ReportController {
 
-    private EncounterReportService encounterReportService;
+    private final EncounterReportService encounterReportService;
 
     @PostMapping(value = "/report", consumes = {TEXT_XML_VALUE, APPLICATION_XML_VALUE})
     @ResponseStatus(value = ACCEPTED)
     public void postReport(@RequestBody String reportXml) {
         try {
             Map<ReportElement, String> reportElementsMap = ReportParserUtil.parseReportXml(reportXml);
+            LOGGER.info(String.format("ITK SOAP message received. MessageId: %s, ItkTrackingId: %s",
+                reportElementsMap.get(ReportElement.MESSAGE_ID), reportElementsMap.get(ReportElement.TRACKING_ID)));
 
             POCDMT000002UK01ClinicalDocument1 clinicalDocument = extractClinicalDocument(reportElementsMap
-                    .get(ReportElement.DISTRIBUTION_ENVELOPE));
+                .get(ReportElement.DISTRIBUTION_ENVELOPE));
             validate(clinicalDocument);
 
-            encounterReportService.transformAndPopulateToGP(clinicalDocument, reportElementsMap.get(ReportElement.MESSAGE_ID));
+            encounterReportService.transformAndPopulateToGP(clinicalDocument, reportElementsMap.get(ReportElement.MESSAGE_ID),
+                reportElementsMap.get(ReportElement.TRACKING_ID));
         } catch (XmlException | DocumentException e) {
+            LOGGER.error(BAD_REQUEST.toString() + e.getMessage());
             throw new ResponseStatusException(BAD_REQUEST, e.getMessage());
         }
     }

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
@@ -5,6 +5,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
+import static uk.nhs.adaptors.oneoneone.cda.report.controller.utils.ReportElement.MESSAGE_ID;
+import static uk.nhs.adaptors.oneoneone.cda.report.controller.utils.ReportElement.TRACKING_ID;
 import static uk.nhs.adaptors.oneoneone.cda.report.controller.utils.ReportRequestUtils.extractClinicalDocument;
 import static uk.nhs.adaptors.oneoneone.xml.XmlValidator.validate;
 
@@ -37,15 +39,15 @@ public class ReportController {
     public void postReport(@RequestBody String reportXml) {
         try {
             Map<ReportElement, String> reportElementsMap = ReportParserUtil.parseReportXml(reportXml);
-            LOGGER.info(String.format("ITK SOAP message received. MessageId: %s, ItkTrackingId: %s",
-                reportElementsMap.get(ReportElement.MESSAGE_ID), reportElementsMap.get(ReportElement.TRACKING_ID)));
+            LOGGER.info("ITK SOAP message received. MessageId: {}, ItkTrackingId: {}",
+                reportElementsMap.get(MESSAGE_ID), reportElementsMap.get(TRACKING_ID));
 
             POCDMT000002UK01ClinicalDocument1 clinicalDocument = extractClinicalDocument(reportElementsMap
                 .get(ReportElement.DISTRIBUTION_ENVELOPE));
             validate(clinicalDocument);
 
-            encounterReportService.transformAndPopulateToGP(clinicalDocument, reportElementsMap.get(ReportElement.MESSAGE_ID),
-                reportElementsMap.get(ReportElement.TRACKING_ID));
+            encounterReportService.transformAndPopulateToGP(clinicalDocument, reportElementsMap.get(MESSAGE_ID),
+                reportElementsMap.get(TRACKING_ID));
         } catch (XmlException | DocumentException e) {
             LOGGER.error(BAD_REQUEST.toString() + e.getMessage());
             throw new ResponseStatusException(BAD_REQUEST, e.getMessage());

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/utils/ReportElement.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/utils/ReportElement.java
@@ -2,5 +2,6 @@ package uk.nhs.adaptors.oneoneone.cda.report.controller.utils;
 
 public enum ReportElement {
     MESSAGE_ID,
-    DISTRIBUTION_ENVELOPE
+    DISTRIBUTION_ENVELOPE,
+    TRACKING_ID
 }

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/utils/ReportParserUtil.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/utils/ReportParserUtil.java
@@ -1,18 +1,20 @@
 package uk.nhs.adaptors.oneoneone.cda.report.controller.utils;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.Node;
-import org.dom4j.io.SAXReader;
-
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.Node;
+import org.dom4j.io.SAXReader;
 
 public class ReportParserUtil {
 
     private static final String MESSAGE_ID_NODE = "//*[local-name()='MessageID']";
     private static final String DISTRIBUTION_ENVELOPE_NODE = "//*[local-name()='DistributionEnvelope']";
+    private static final String HEADER_NODE = "//*[local-name()='header']";
 
     public static Map<ReportElement, String> parseReportXml(String reportXml) throws DocumentException {
 
@@ -23,6 +25,7 @@ public class ReportParserUtil {
 
         reportElementsMap.put(ReportElement.MESSAGE_ID, getMessageId(document));
         reportElementsMap.put(ReportElement.DISTRIBUTION_ENVELOPE, getDistributionEnvelope(document));
+        reportElementsMap.put(ReportElement.TRACKING_ID, getTrackingId(document));
         return reportElementsMap;
     }
 
@@ -34,5 +37,11 @@ public class ReportParserUtil {
     private static String getDistributionEnvelope(Document document) {
         Node distributionEnvelopeNode = document.selectSingleNode(DISTRIBUTION_ENVELOPE_NODE);
         return distributionEnvelopeNode.asXML();
+    }
+
+    private static String getTrackingId(Document document) {
+        String trackingId = "trackingid";
+        Element element = (Element) document.selectSingleNode(HEADER_NODE);
+        return element.attribute(trackingId).getValue();
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportService.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportService.java
@@ -35,7 +35,7 @@ public class EncounterReportService {
             message.setStringProperty(MESSAGE_ID, messageId);
             return message;
         });
-        LOGGER.info(String.format("Successfully sent FHIR message to queue. MessageId: %s, ItkTrackingId: %s", messageId, trackingId));
+        LOGGER.info("Successfully sent FHIR message to queue. MessageId: {}, ItkTrackingId: {}", messageId, trackingId);
     }
 
     private String toJsonString(Bundle encounterBundle) {

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportService.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportService.java
@@ -1,30 +1,33 @@
 package uk.nhs.adaptors.oneoneone.cda.report.service;
 
-import ca.uhn.fhir.context.FhirContext;
-import lombok.AllArgsConstructor;
+import javax.jms.TextMessage;
+
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Service;
+
+import ca.uhn.fhir.context.FhirContext;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import uk.nhs.adaptors.oneoneone.config.AmqpProperties;
 import uk.nhs.connect.iucds.cda.ucr.POCDMT000002UK01ClinicalDocument1;
 
-import javax.jms.TextMessage;
-
 @Service
+@Slf4j
 @AllArgsConstructor
 public class EncounterReportService {
 
     private static final String MESSAGE_ID = "messageId";
 
-    private EncounterReportBundleService encounterReportBundleService;
+    private final EncounterReportBundleService encounterReportBundleService;
 
-    private JmsTemplate jmsTemplate;
+    private final JmsTemplate jmsTemplate;
 
-    private FhirContext fhirContext;
+    private final FhirContext fhirContext;
 
-    private AmqpProperties amqpProperties;
+    private final AmqpProperties amqpProperties;
 
-    public void transformAndPopulateToGP(POCDMT000002UK01ClinicalDocument1 clinicalDocumentDocument, String messageId) {
+    public void transformAndPopulateToGP(POCDMT000002UK01ClinicalDocument1 clinicalDocumentDocument, String messageId, String trackingId) {
         Bundle encounterBundle = encounterReportBundleService.createEncounterBundle(clinicalDocumentDocument);
 
         jmsTemplate.send(amqpProperties.getQueueName(), session -> {
@@ -32,11 +35,12 @@ public class EncounterReportService {
             message.setStringProperty(MESSAGE_ID, messageId);
             return message;
         });
+        LOGGER.info(String.format("Successfully sent FHIR message to queue. MessageId: %s, ItkTrackingId: %s", messageId, trackingId));
     }
 
     private String toJsonString(Bundle encounterBundle) {
         return fhirContext
-                .newJsonParser()
-                .encodeResourceToString(encounterBundle);
+            .newJsonParser()
+            .encodeResourceToString(encounterBundle);
     }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,3 +1,11 @@
+logging:
+  level:
+    uk:
+      nhs:
+        adaptors:
+          oneoneone:
+            cda:
+              report: DEBUG
 amqp:
   broker: ${PEM111_AMQP_BROKER:amqp://localhost:5672}
   queueName: ${PEM111_AMQP_QUEUE_NAME:encounter-report}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ logging:
         adaptors:
           oneoneone:
             cda:
-              report: DEBUG
+              report: ${LOG_LEVEL}
 amqp:
   broker: ${PEM111_AMQP_BROKER:amqp://localhost:5672}
   queueName: ${PEM111_AMQP_QUEUE_NAME:encounter-report}

--- a/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportControllerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportControllerTest.java
@@ -1,5 +1,16 @@
 package uk.nhs.adaptors.oneoneone.cda.report.controller;
 
+import static java.nio.file.Files.readAllBytes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import java.net.URL;
+import java.nio.file.Paths;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -7,23 +18,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.web.server.ResponseStatusException;
+
 import uk.nhs.adaptors.oneoneone.cda.report.service.EncounterReportService;
 import uk.nhs.connect.iucds.cda.ucr.POCDMT000002UK01ClinicalDocument1;
-
-import java.net.URL;
-import java.nio.file.Paths;
-
-import static java.nio.file.Files.readAllBytes;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReportControllerTest {
 
     private static final String MESSAGE_ID = "2B77B3F5-3016-4A6D-821F-152CE420E58D";
+    private static final String TRACKING_ID = "7D6F23E0-AE1A-11DB-9808-B18E1E0994CD";
 
     @InjectMocks
     private ReportController reportController;
@@ -38,10 +41,19 @@ public class ReportControllerTest {
         reportController.postReport(validRequest);
 
         ArgumentCaptor<POCDMT000002UK01ClinicalDocument1> captor = ArgumentCaptor.forClass(POCDMT000002UK01ClinicalDocument1.class);
-        verify(encounterReportService).transformAndPopulateToGP(captor.capture(), eq(MESSAGE_ID));
+        verify(encounterReportService).transformAndPopulateToGP(captor.capture(), eq(MESSAGE_ID), eq(TRACKING_ID));
         POCDMT000002UK01ClinicalDocument1 clinicalDocument = captor.getValue();
         assertThat(clinicalDocument.getId().getRoot()).isEqualTo("A709A442-3CF4-476E-8377-376500E829C9");
         assertThat(clinicalDocument.getSetId().getRoot()).isEqualTo("411910CF-1A76-4330-98FE-C345DDEE5553");
+    }
+
+    private String getValidReportRequest() {
+        try {
+            URL reportXmlResource = this.getClass().getResource("/xml/ITK_Report_request.xml");
+            return new String(readAllBytes(Paths.get(reportXmlResource.getPath())));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -58,15 +70,6 @@ public class ReportControllerTest {
 
         if (!exceptionThrown) {
             fail("ResponseStatusException should have been thrown");
-        }
-    }
-
-    private String getValidReportRequest() {
-        try {
-            URL reportXmlResource = this.getClass().getResource("/xml/ITK_Report_request.xml");
-            return new String(readAllBytes(Paths.get(reportXmlResource.getPath())));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/service/EncounterReportServiceTest.java
@@ -1,7 +1,15 @@
 package uk.nhs.adaptors.oneoneone.cda.report.service;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.jms.JMSException;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,18 +20,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessageCreator;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
 import uk.nhs.adaptors.oneoneone.config.AmqpProperties;
 import uk.nhs.connect.iucds.cda.ucr.POCDMT000002UK01ClinicalDocument1;
-
-import javax.jms.JMSException;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EncounterReportServiceTest {
@@ -31,6 +32,7 @@ public class EncounterReportServiceTest {
     private static final String ENCOUNTER_REPORT_MAPPING = "<encounter-report-mapping>";
     private static final String QUEUE_NAME = "Encounter-Report";
     private static final String MESSAGE_ID = "2B77B3F5-3016-4A6D-821F-152CE420E58D";
+    private static final String TRACKING_ID = "7D6F23E0-AE1A-11DB-9808-B18E1E0994CD";
 
     @InjectMocks
     private EncounterReportService encounterReportService;
@@ -66,7 +68,7 @@ public class EncounterReportServiceTest {
         Session session = mock(Session.class);
         when(session.createTextMessage(any())).thenReturn(textMessage);
 
-        encounterReportService.transformAndPopulateToGP(clinicalDoc, MESSAGE_ID);
+        encounterReportService.transformAndPopulateToGP(clinicalDoc, MESSAGE_ID, TRACKING_ID);
 
         ArgumentCaptor<MessageCreator> argumentCaptor = ArgumentCaptor.forClass(MessageCreator.class);
         verify(jmsTemplate).send(eq(QUEUE_NAME), argumentCaptor.capture());


### PR DESCRIPTION
Logging INFO level added for incoming messages and translated messages successfully add to queue. ERROR level added display entire error message for exceptions. Tracking ID extracted from header node for INFO level logs. INFO logs display tracking and message id.