### PR TITLE
NIAD-463: Vulnerable modules in integration-adaptor-111

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -21,21 +21,58 @@ repositories {
 }
 
 dependencies {
-    implementation "org.springframework.boot:spring-boot-starter-web:2.3.1.RELEASE"
+    implementation("org.springframework.boot:spring-boot-starter-web:2.3.1.RELEASE") {
+        exclude group: "org.apache.tomcat", module: "tomcat-embed-core"
+        exclude group: "org.springframework", module: "spring-web"
+        exclude group: "org.springframework", module: "spring-webmvc"
+        exclude group: "org.yaml", module: "snakeyaml"
+    }
+    implementation "org.yaml:snakeyaml:1.26"
+    implementation "org.springframework:spring-webmvc:5.2.8.RELEASE"
+    implementation "org.springframework:spring-web:5.2.8.RELEASE"
+    implementation "org.apache.tomcat.embed:tomcat-embed-core:9.0.37"
     implementation 'org.apache.qpid:qpid-jms-client:0.51.0'
-    implementation 'org.springframework:spring-jms:5.2.6.RELEASE'
-    implementation "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:4.2.0"
+    implementation("org.springframework:spring-jms:5.2.6.RELEASE") {
+        exclude group: "org.apache.tomcat", module: "tomcat-embed-core"
+        exclude group: "org.springframework", module: "spring-web"
+        exclude group: "org.springframework", module: "spring-webmvc"
+        exclude group: "org.yaml", module: "snakeyaml"
+    }
+    implementation("ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:4.2.0") {
+        exclude group: "commons-codec", module: "commons-codec"
+    }
+    implementation "commons-codec:commons-codec:1.13"
     implementation "uk.nhs.connect.iucds:iucds-schema:3.0.RC1.2"
-    implementation "org.springframework.boot:spring-boot-starter-actuator:2.3.1.RELEASE"
-    implementation "dom4j:dom4j:1.6.1"
+    implementation("org.springframework.boot:spring-boot-starter-actuator:2.3.1.RELEASE") {
+        exclude group: "org.apache.tomcat", module: "tomcat-embed-core"
+        exclude group: "org.springframework", module: "spring-web"
+        exclude group: "org.springframework", module: "spring-webmvc"
+        exclude group: "org.yaml", module: "snakeyaml"
+    }
+    implementation "org.dom4j:dom4j:2.1.3"
     implementation "jaxen:jaxen:1.2.0"
 
     testImplementation "junit:junit:4.13"
     testImplementation "org.mockito:mockito-core:3.3.3"
     testImplementation "org.assertj:assertj-core:3.16.1"
-    testImplementation "org.springframework.boot:spring-boot-starter-test:2.3.1.RELEASE"
+    testImplementation("org.springframework.boot:spring-boot-starter-test:2.3.1.RELEASE") {
+        exclude group: "org.apache.tomcat", module: "tomcat-embed-core"
+        exclude group: "org.springframework", module: "spring-web"
+        exclude group: "org.springframework", module: "spring-webmvc"
+        exclude group: "org.yaml", module: "snakeyaml"
+    }
     testImplementation "io.rest-assured:rest-assured:4.3.0"
     testImplementation "ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:4.2.0"
+
+    components {
+        withModule('org.dom4j:dom4j', ClearDependencies)
+    }
+}
+
+class ClearDependencies implements ComponentMetadataRule {
+    void execute(ComponentMetadataContext context) {
+        context.details.allVariants { withDependencies { clear() } }
+    }
 }
 
 lombok {


### PR DESCRIPTION
Transitive dependency modules updated to latest version, all tests pass, no venerabilities, optional dependency bug with dom4j fix implemented, further details on jira ticket. https://gpitbjss.atlassian.net/secure/RapidBoard.jspa?rapidView=75&projectKey=NIAD&modal=detail&selectedIssue=NIAD-463 