### PR TITLE
Niad 2124 test suite safeguarding referral

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
@@ -12,6 +12,7 @@ import static uk.nhs.adaptors.oneoneone.xml.XmlValidator.validate;
 
 import org.apache.xmlbeans.XmlException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -57,6 +58,7 @@ public class ReportController {
     private final ReportParserUtil reportParserUtil;
     private final ReportRequestUtils reportRequestUtils;
 
+    @CrossOrigin("http://localhost:3000")
     @PostMapping(value = "/report",
         consumes = {APPLICATION_XML_VALUE, TEXT_XML_VALUE},
         produces = TEXT_XML_VALUE

--- a/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
+++ b/service/src/main/java/uk/nhs/adaptors/oneoneone/cda/report/controller/ReportController.java
@@ -12,7 +12,6 @@ import static uk.nhs.adaptors.oneoneone.xml.XmlValidator.validate;
 
 import org.apache.xmlbeans.XmlException;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -58,7 +57,6 @@ public class ReportController {
     private final ReportParserUtil reportParserUtil;
     private final ReportRequestUtils reportRequestUtils;
 
-    @CrossOrigin("http://localhost:3000")
     @PostMapping(value = "/report",
         consumes = {APPLICATION_XML_VALUE, TEXT_XML_VALUE},
         produces = TEXT_XML_VALUE

--- a/test-suite/src/components/RequestForm.tsx
+++ b/test-suite/src/components/RequestForm.tsx
@@ -112,17 +112,18 @@ const RequestForm = ({ name, specs, template, globals }: Props) => {
                 {v.map((field: TestRequestField) => {
                   const key = k as keyof AdaptorRequest;
                   return (
-                      <div key={"K-" + name + key + field.id}>
+                      <Col width="one-half" key={"K-" + name + key + field.id}>
                         {field.date ? (
-                            <Col width="one-half">
-                              {dateInputElement(field, key)}
-                            </Col>
-                        ) : (
-                            <Col width="one-half">
-                              {textInputElement(field, key)}
-                            </Col>
+                          <React.Fragment>
+                            {dateInputElement(field, key)}
+                          </React.Fragment>
+                          )
+                          : (
+                          <React.Fragment>
+                            {textInputElement(field, key)}
+                          </React.Fragment>
                         )}
-                      </div>
+                      </Col>
                   );
                 })}
                 {i === specEntries.length - 1 && (

--- a/test-suite/src/components/RequestForm.tsx
+++ b/test-suite/src/components/RequestForm.tsx
@@ -24,6 +24,7 @@ const RequestForm = ({ name, specs, template, globals }: Props) => {
   );
   const [errors, setErrors] = useState<FormErrors>(createRequestErrors(specs));
   const [response, setResponse] = useState<AdaptorResponse | null>(null);
+  const datePlaceholder: string = "YYYYMMDDhhmm"
 
   const specEntries = Object.entries(specs);
 
@@ -60,6 +61,47 @@ const RequestForm = ({ name, specs, template, globals }: Props) => {
     return errorMessage;
   };
 
+  const textInputElement = (field: TestRequestField, key: keyof AdaptorRequest) => (
+      <Input
+          id={field.id}
+          name={field.id}
+          label={field.label}
+          value={form[key][field.id]}
+          error={inputError(field.id)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            onValidate(field.id, e.target.value);
+            setForm({
+              ...form,
+              [key]: {
+                ...form[key],
+                [field.id]: e.target.value,
+              },
+            });
+          }}
+      />
+  );
+
+  const dateInputElement = (field: TestRequestField, key: keyof AdaptorRequest) => (
+      <Input
+          id={field.id}
+          name={field.id}
+          label={field.label}
+          placeholder={datePlaceholder}
+          value={form[key][field.id]}
+          error={inputError(field.id)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            onValidate(field.id, e.target.value);
+            setForm({
+              ...form,
+              [key]: {
+                ...form[key],
+                [field.id]: e.target.value,
+              },
+            });
+          }}
+      />
+  )
+
   return (
     <Card>
       <Card.Content>
@@ -70,25 +112,17 @@ const RequestForm = ({ name, specs, template, globals }: Props) => {
                 {v.map((field: TestRequestField) => {
                   const key = k as keyof AdaptorRequest;
                   return (
-                    <Col width="one-half" key={"K-" + name + key + field.id}>
-                      <Input
-                        id={field.id}
-                        name={field.id}
-                        label={field.label}
-                        value={form[key][field.id]}
-                        error={inputError(field.id)}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                          onValidate(field.id, e.target.value);
-                          setForm({
-                            ...form,
-                            [key]: {
-                              ...form[key],
-                              [field.id]: e.target.value,
-                            },
-                          });
-                        }}
-                      />
-                    </Col>
+                      <div key={"K-" + name + key + field.id}>
+                        {field.date ? (
+                            <Col width="one-half">
+                              {dateInputElement(field, key)}
+                            </Col>
+                        ) : (
+                            <Col width="one-half">
+                              {textInputElement(field, key)}
+                            </Col>
+                        )}
+                      </div>
                   );
                 })}
                 {i === specEntries.length - 1 && (

--- a/test-suite/src/data/safeguarding-request.xml
+++ b/test-suite/src/data/safeguarding-request.xml
@@ -11,8 +11,8 @@
             <wsu:Timestamp
                     xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
                     wsu:Id="D6CD5232-14CF-11DF-9423-1F9A910D4703">
-                <wsu:Created>%certficate-created-date-time%Z</wsu:Created>
-                <wsu:Expires>%certificate-expires-date-time%Z</wsu:Expires>
+                <wsu:Created>@@certficate-created-date-time@@Z</wsu:Created>
+                <wsu:Expires>@@certificate-expires-date-time@@Z</wsu:Expires>
             </wsu:Timestamp>
             <wsse:UsernameToken>
                 <wsse:Username>TKS Server test</wsse:Username>
@@ -27,8 +27,8 @@
             <itk:header service="urn:nhs-itk:services:201005:SendNHS111Report-v2-0_DMS"
                         trackingid="7D6F23E0-AE1A-11DB-9808-B18E1E0994CD">
                 <itk:addresslist>
-                    <itk:address uri="urn:nhs-uk:addressing:ods:%ODS-CODE%"/>
-                    <itk:address type="2.16.840.1.113883.2.1.3.2.4.18.44" uri="%DOS-CODE%" />
+                    <itk:address uri="urn:nhs-uk:addressing:ods:@@ods-code@@"/>
+                    <itk:address type="2.16.840.1.113883.2.1.3.2.4.18.44" uri="@@dos-code@@" />
                 </itk:addresslist>
                 <itk:auditIdentity>
                     <itk:id uri="urn:nhs-uk:identity:ods:5L399"/>
@@ -67,7 +67,7 @@
                                 <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
                                     assigningAuthorityName="Medway NHS Foundation Trust"/>
                                 <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
-                                <id extension="%NHS-NUMBER%" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
+                                <id extension="@@nhs-number@@" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>
                                     <streetAddressLine>Woodtown</streetAddressLine>
@@ -185,18 +185,18 @@
                                 <templateId extension="COCD_TP145203GB03#IntendedRecipient"
                                             root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
                                 <addr use="WP">
-                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-LINE-1%</streetAddressLine>
-                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-LINE-2%</streetAddressLine>
-                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-TOWN%</streetAddressLine>
-                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-CITY%</streetAddressLine>
-                                    <postalCode>%RECIPIENT-STREET-ADDRESS-POSTCODE%</postalCode>
+                                    <streetAddressLine>@@recipient-street-address-line-1@@</streetAddressLine>
+                                    <streetAddressLine>@@recipient-street-address-line-2@@</streetAddressLine>
+                                    <streetAddressLine>@@recipient-street-address-town@@</streetAddressLine>
+                                    <streetAddressLine>@@recipient-street-address-city@@</streetAddressLine>
+                                    <postalCode>@@recipient-street-address-postcode@@</postalCode>
                                 </addr>
                                 <telecom use="WP" value="tel:0123476895"/>
                                 <receivedOrganization classCode="ORG" determinerCode="INSTANCE">
                                     <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
                                                 extension="COCD_TP145203GB03#representedOrganization"/>
                                     <id root="2.16.840.1.113883.2.1.3.2.4.19.2" extension="PRA123"/>
-                                    <name>%RECIPIENT-NAME%</name>
+                                    <name>@@recipient-name@@</name>
                                 </receivedOrganization>
                             </intendedRecipient>
                         </informationRecipient>
@@ -283,8 +283,8 @@
                                 <code code="NHS111Encounter" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.326"
                                       displayName="NHS111 Encounter"/>
                                 <effectiveTime>
-                                    <low value="%NHS111-ENCOUNTER-DATE-TIME-START%+00"/>
-                                    <high value="%NHS111-ENCOUNTER-DATE-TIME-END%+00"/>
+                                    <low value="@@nhs111-encounter-date-time-start@@"/>
+                                    <high value="@@nhs111-encounter-date-time-end@@"/>
                                 </effectiveTime>
                                 <dischargeDispositionCode code="Dx42" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.325"
                                                           displayName="Child protection / Vulnerable adult immediate referral

--- a/test-suite/src/data/safeguarding-request.xml
+++ b/test-suite/src/data/safeguarding-request.xml
@@ -1,0 +1,694 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+    <s:Header>
+        <a:Action s:mustUnderstand="1">urn:nhs-itk:services:201005:SendNHS111Report-v2-0_DMS</a:Action>
+        <a:MessageID>2B77B3F5-3016-4A6D-821F-152CE420E58D</a:MessageID>
+        <a:ReplyTo>
+            <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
+        </a:ReplyTo>
+        <a:To s:mustUnderstand="1">http://localhost:8080/report</a:To>
+        <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+            <wsu:Timestamp
+                    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                    wsu:Id="D6CD5232-14CF-11DF-9423-1F9A910D4703">
+                <wsu:Created>%certficate-created-date-time%Z</wsu:Created>
+                <wsu:Expires>%certificate-expires-date-time%Z</wsu:Expires>
+            </wsu:Timestamp>
+            <wsse:UsernameToken>
+                <wsse:Username>TKS Server test</wsse:Username>
+            </wsse:UsernameToken>
+        </wsse:Security>
+    </s:Header>
+    <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+        <itk:DistributionEnvelope xmlns:itk="urn:nhs-itk:ns:201005"
+                                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <itk:header service="urn:nhs-itk:services:201005:SendNHS111Report-v2-0_DMS"
+                        trackingid="7D6F23E0-AE1A-11DB-9808-B18E1E0994CD">
+                <itk:addresslist>
+                    <itk:address uri="urn:nhs-uk:addressing:ods:%ODS-CODE%"/>
+                    <itk:address type="2.16.840.1.113883.2.1.3.2.4.18.44" uri="%DOS-CODE%" />
+                </itk:addresslist>
+                <itk:auditIdentity>
+                    <itk:id uri="urn:nhs-uk:identity:ods:5L399"/>
+                </itk:auditIdentity>
+                <itk:manifest count="1">
+                    <itk:manifestitem mimetype="text/xml" id="uuid_7D6F23E0-AE1A-11DB-9808-B18E1E0994EE" profileid="urn:nhs-en:profile:IntegratedUrgentCareCDADocument-v3-1"/>
+                </itk:manifest>
+                <itk:senderAddress uri="urn:nhs-uk:addressing:ods:5L399:445510770"/>
+                <itk:handlingSpecification>
+                    <itk:spec value="urn:nhs-itk:interaction:copyRecipientNHS111CDADocument-v2-0" key="urn:nhs-itk:ns:201005:interaction"/>
+                </itk:handlingSpecification>
+            </itk:header>
+            <itk:payloads count="1">
+                <itk:payload id="uuid_7D6F23E0-AE1A-11DB-9808-B18E1E0994EE">
+                    <ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:npfitlc="NPFIT:HL7:Localisation"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" classCode="DOCCLIN"
+                                      moodCode="EVN">
+
+
+                        <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+                        <npfitlc:messageType root="2.16.840.1.113883.2.1.3.2.4.18.17" extension="POCD_MT200001GB02"/>
+                        <id root="A709A442-3CF4-476E-8377-376500E829C9"/>
+                        <code code="1066271000000101" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                        <title>Integrated Urgent Care Report</title>
+                        <effectiveTime value="201701012000+00"/>
+                        <confidentialityCode code="V" displayName="very restricted"
+                                             codeSystem="2.16.840.1.113883.1.11.16926"/>
+                        <setId root="411910CF-1A76-4330-98FE-C345DDEE5553"/>
+                        <versionNumber value="2"/>
+                        <recordTarget typeCode="RCT" contextControlCode="OP">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP145201GB01#PatientRole"/>
+                            <patientRole classCode="PAT">
+                                <templateId extension="COCD_TP145201GB01#PatientRole"
+                                            root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
+                                    assigningAuthorityName="Medway NHS Foundation Trust"/>
+                                <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
+                                <id extension="%NHS_NUMBER%" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
+                                <addr use="H">
+                                    <streetAddressLine>17, County Avenue</streetAddressLine>
+                                    <streetAddressLine>Woodtown</streetAddressLine>
+                                    <city>Medway</city>
+                                    <postalCode>ME5 FS3</postalCode>
+                                </addr>
+                                <telecom value="tel:01634775667" use="H"/>
+                                <telecom value="tel:01634451628" use="HV"/>
+                                <telecom value="mailto:Joe.Blogg@emailfree.co.uk" use="H"/>
+                                <patient classCode="PSN" determinerCode="INSTANCE">
+                                    <templateId extension="COCD_TP145201GB01#patientPatient"
+                                                root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                    <name>
+                                        <prefix>Mr</prefix>
+                                        <family>Joe</family>
+                                        <given>Blogg</given>
+                                    </name>
+                                    <administrativeGenderCode codeSystem="2.16.840.1.113883.2.1.3.2.4.16.25"
+                                                              displayName="Male" code="1"/>
+                                    <birthTime value="19890101"/>
+                                    <languageCommunication>
+                                        <templateId extension="COCD_TP145201GB01#languageCommunication"
+                                                    root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                        <languageCode codeSystem="2.16.840.1.113883.2.1.3.2.4.17.70" code="en"/>
+                                    </languageCommunication>
+                                </patient>
+                                <providerOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145201GB01#providerOrganization"/>
+                                    <id root="2.16.840.1.113883.2.1.3.2.4.19.1" extension="V396F"/>
+                                    <name>Medway Medical Practice</name>
+                                    <telecom value="tel:01634111222" use="WP"/>
+                                    <addr use="WP">
+                                        <streetAddressLine>Springer Street</streetAddressLine>
+                                        <city>Medway</city>
+                                        <postalCode>ME5 5TY</postalCode>
+                                    </addr>
+                                    <standardIndustryClassCode code="001" displayName="GP Practice"
+                                                               codeSystem="2.16.840.1.113883.2.1.3.2.4.17.289"/>
+                                </providerOrganization>
+                            </patientRole>
+                        </recordTarget>
+                        <author typeCode="AUT" contextControlCode="OP">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP145200GB01#AssignedAuthor"/>
+                            <functionCode code="OA" displayName="Originating Author"
+                                          codeSystem="2.16.840.1.113883.2.1.3.2.4.17.178"/>
+                            <time value="201901012000+00"/>
+                            <assignedAuthor classCode="ASSIGNED">
+                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                            extension="COCD_TP145200GB01#AssignedAuthor"/>
+                                <id root="2.16.840.1.113883.2.1.3.2.4.18.24" extension="MARY100"
+                                    assigningAuthorityName="Medway NHS Foundation Trust"/>
+                                <code code="T1" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.196"
+                                      displayName="Nurse Triage Practitioner"/>
+                                <assignedPerson classCode="PSN" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145200GB01#assignedPerson"/>
+                                    <name>
+                                        <given>Mary</given>
+                                        <family>Jones</family>
+                                    </name>
+                                </assignedPerson>
+                                <representedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145200GB01#representedOrganization"/>
+                                    <id root="2.16.840.1.113883.2.1.3.2.4.19.1" extension="5L399"/>
+                                    <name>Medway NHS Foundation Trust</name>
+                                </representedOrganization>
+                            </assignedAuthor>
+                        </author>
+                        <informant typeCode="INF" contextControlCode="OP">
+                            <npfitlc:contentId extension="COCD_TP145007UK05#RelatedEntity"
+                                               root="2.16.840.1.113883.2.1.3.2.4.18.16"/>
+                            <relatedEntity classCode="PRS">
+                                <templateId extension="COCD_TP145007UK05#RelatedEntity"
+                                            root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                <code code="01" codeSystem="2.16.840.1.113883.2.1.3.2.4.16.45" displayName="Spouse"/>
+                                <addr use="HP">
+                                    <streetAddressLine>43 Summers Avenue</streetAddressLine>
+                                    <streetAddressLine>Somerset Street</streetAddressLine>
+                                    <city>Medway</city>
+                                    <postalCode>ME5 7TY</postalCode>
+                                </addr>
+                                <telecom value="tel:07886554123" use="MC"/>
+                                <telecom value="tel:01783678321" use="HP"/>
+                                <relatedPerson classCode="PSN" determinerCode="INSTANCE">
+                                    <templateId extension="COCD_TP145007UK05#relationshipHolder"
+                                                root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                    <name>
+                                        <given>Helga</given>
+                                        <family>Bloggs</family>
+                                    </name>
+                                </relatedPerson>
+                            </relatedEntity>
+                        </informant>
+                        <custodian typeCode="CST">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP145018UK03#AssignedCustodian"/>
+                            <assignedCustodian classCode="ASSIGNED">
+                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                            extension="COCD_TP145018UK03#AssignedCustodian"/>
+                                <representedCustodianOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145018UK03#representedCustodianOrganization"/>
+                                    <id root="2.16.840.1.113883.2.1.3.2.4.19.1" extension="5L3"/>
+                                    <name>Medway NHS Foundation Trust</name>
+                                </representedCustodianOrganization>
+                            </assignedCustodian>
+                        </custodian>
+                        <informationRecipient typeCode="PRCP">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP145203GB03#IntendedRecipient"/>
+                            <intendedRecipient classCode="ASSIGNED">
+                                <templateId extension="COCD_TP145203GB03#IntendedRecipient"
+                                            root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                <addr use="WP">
+                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_LINE_1%</streetAddressLine>
+                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_LINE_2%</streetAddressLine>
+                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_TOWN%</streetAddressLine>
+                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_CITY%</streetAddressLine>
+                                    <postalCode>%RECIPIENT_STREET_ADDRESS_POSTCODE%</postalCode>
+                                </addr>
+                                <telecom use="WP" value="tel:0123476895"/>
+                                <receivedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145203GB03#representedOrganization"/>
+                                    <id root="2.16.840.1.113883.2.1.3.2.4.19.2" extension="PRA123"/>
+                                    <name>%RECIPIENT_NAME%</name>
+                                </receivedOrganization>
+                            </intendedRecipient>
+                        </informationRecipient>
+                        <informationRecipient typeCode="PRCP">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP145203GB03#IntendedRecipient"/>
+                            <intendedRecipient classCode="ASSIGNED">
+                                <templateId extension="COCD_TP145203GB03#IntendedRecipient"
+                                            root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                <receivedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <templateId extension="COCD_TP145203GB03#representedOrganization"
+                                                root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                    <id extension="EM396" root="2.16.840.1.113883.2.1.3.2.4.19.1"/>
+                                    <name>Medway Kent Out of Hours Clinic</name>
+                                </receivedOrganization>
+                            </intendedRecipient>
+                        </informationRecipient>
+                        <participant typeCode="REFT" contextControlCode="OP">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP145214GB01#AssociatedEntity"/>
+                            <associatedEntity classCode="ASSIGNED">
+                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                            extension="COCD_TP145214GB01#AssociatedEntity"/>
+                                <id root="2.16.840.1.113883.2.1.3.2.4.19.2" extension="R8722"/>
+                                <addr use="PHYS">
+                                    <streetAddressLine>Church Street Walk in Centre</streetAddressLine>
+                                    <streetAddressLine>4 Church Street</streetAddressLine>
+                                    <streetAddressLine>Medway</streetAddressLine>
+                                    <postalCode>ME8 7TT</postalCode>
+                                </addr>
+                                <telecom use="EC" value="tel:0123456789"/>
+                                <scopingOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145214GB01#scopingOrganization"/>
+                                    <id root="2.16.840.1.113883.2.1.3.2.4.19.1" extension="RE3"/>
+                                    <name>Medway Community Hospital</name>
+                                </scopingOrganization>
+                            </associatedEntity>
+                        </participant>
+                        <participant typeCode="CALLBCK" contextControlCode="OP">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP145212GB02#Workgroup"/>
+                            <associatedEntity classCode="ASSIGNED">
+                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                            extension="COCD_TP145212GB02#Workgroup"/>
+                                <id nullFlavor="UNK"/>
+                                <code code="01" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.266"
+                                      displayName="Call Centre"/>
+                                <telecom value="tel:08001111111"/>
+                                <associatedPerson classCode="PSN" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145212GB02#assignedPerson"/>
+                                    <name>Call Centre Manager</name>
+                                </associatedPerson>
+                                <scopingOrganization classCode="ORG" determinerCode="INSTANCE">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP145212GB02#representedOrganization"/>
+                                    <id root="2.16.840.1.113883.2.1.3.2.4.19.2" extension="06HAK"/>
+                                    <name>111 CALL CENTRE</name>
+                                </scopingOrganization>
+                            </associatedEntity>
+                        </participant>
+                        <authorization typeCode="AUTH">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP146226GB02#Consent"/>
+                            <consent classCode="CONS" moodCode="EVN">
+                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                            extension="COCD_TP146226GB02#Consent"/>
+                                <id root="A709A442-3CF4-476E-8377-377700E727C7"/>
+                                <code code="425691002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                      displayName="Consent given for electronic record sharing"/>
+                                <statusCode code="completed"/>
+                            </consent>
+                        </authorization>
+                        <componentOf typeCode="COMP">
+                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                               extension="COCD_TP146232GB01#EncompassingEncounter"/>
+                            <encompassingEncounter classCode="ENC" moodCode="EVN">
+                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                            extension="COCD_TP146232GB01#EncompassingEncounter"/>
+                                <id root="2.16.840.1.113883.2.1.3.2.4.18.49" extension="LOC665"/>
+                                <id root="2.16.840.1.113883.2.1.3.2.4.18.34" extension="CASEREF1234"/>
+                                <id root="2.16.840.1.113883.2.1.3.2.4.18.35" extension="CASEID123"/>
+                                <code code="NHS111Encounter" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.326"
+                                      displayName="NHS111 Encounter"/>
+                                <effectiveTime>
+                                    <low value="%NHS111-ENCOUNTER-DATE-TIME-START%+00"/>
+                                    <high value="%NHS111-ENCOUNTER-DATE-TIME-END%+00"/>
+                                </effectiveTime>
+                                <dischargeDispositionCode code="Dx42" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.325"
+                                                          displayName="Child protection / Vulnerable adult immediate referral
+"/>
+                                <responsibleParty typeCode="RESP">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP146232GB01#responsibleParty"/>
+                                    <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                       extension="COCD_TP145210GB01#AssignedEntity"/>
+                                    <assignedEntity classCode="ASSIGNED">
+                                        <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                    extension="COCD_TP145210GB01#AssignedEntity"/>
+                                        <id nullFlavor="NI"/>
+                                        <code code="R0010" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.196"
+                                              displayName="Medical Director"/>
+                                        <assignedPerson classCode="PSN" determinerCode="INSTANCE">
+                                            <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                        extension="COCD_TP145210GB01#assignedPerson"/>
+                                            <name>
+                                                <given>Dave</given>
+                                                <family>Cornwell</family>
+                                            </name>
+                                        </assignedPerson>
+                                        <representedOrganization classCode="ORG" determinerCode="INSTANCE">
+                                            <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                        extension="COCD_TP145210GB01#representedOrganization"/>
+                                            <id root="2.16.840.1.113883.2.1.3.2.4.19.1" extension="VDE232323"/>
+                                            <name>Medway South Out of Hours Centre</name>
+                                        </representedOrganization>
+                                    </assignedEntity>
+                                </responsibleParty>
+                                <location typeCode="LOC">
+                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                extension="COCD_TP146232GB01#location"/>
+                                    <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                       extension="COCD_TP145222GB02#HealthCareFacility"/>
+                                    <healthCareFacility classCode="ISDLOC">
+                                        <templateId extension="COCD_TP145222GB02#HealthCareFacility"
+                                                    root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                        <id nullFlavor="NA"/>
+                                        <code code="313161000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                              displayName="Example Care Setting"/>
+                                        <location classCode="PLC" determinerCode="INSTANCE">
+                                            <templateId extension="COCD_TP145222GB02#location"
+                                                        root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                            <name>Incident Location</name>
+                                            <addr use="PHYS">
+                                                <streetAddressLine>2, Brancaster Road</streetAddressLine>
+                                                <city>Medway</city>
+                                                <postalCode>ME5 4LS</postalCode>
+                                                <desc>Follow the high street and turn left by Boots</desc>
+                                                <country>GB</country>
+                                                <country>Great Britain</country>
+                                                <addressKey>962145269574</addressKey>
+                                                <additionalLocator>+38.265789-85.623415</additionalLocator>
+                                                <additionalLocator>X575776,Y163180</additionalLocator>
+                                            </addr>
+                                        </location>
+                                    </healthCareFacility>
+                                </location>
+                            </encompassingEncounter>
+                        </componentOf>
+                        <component typeCode="COMP" contextConductionInd="true">
+                            <structuredBody classCode="DOCBODY" moodCode="EVN">
+                                <component typeCode="COMP" contextConductionInd="true">
+                                    <section classCode="DOCSECT" moodCode="EVN">
+                                        <id root="7AFDCAD6-1CE3-45A6-A176-DDAC27F46C87"/>
+                                        <entry typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId extension="COCD_TP146002GB01#ObservationMedia"
+                                                               root="2.16.840.1.113883.2.1.3.2.4.18.16"/>
+                                            <observationMedia classCode="OBS" moodCode="EVN">
+                                                <templateId extension="COCD_TP146002GB01#ObservationMedia"
+                                                            root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
+                                                <id root="7DAC2CE0-AE1A-11DB-98EE-B18E1E0994CD"/>
+                                                <value xsi:type="ST" representation="B64" mediaType="text/xml">
+                                                    PFBhdGh3YXlzQ2FzZSB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4c2k6c2NoZW1hTG9jYXRpb249Imh0dHA6Ly9uaHNwYXRod2F5cy5vcmcvd2Vic2VydmljZXMvcGF0aHdheXMvcGF0aHdheXNDYXNlIGZpbGU6Ly8vRDovQ29ubmVjdGluZ2ZvckhlYWx0aC9Qcm9qZWN0cy9OSFMxMTEvUGF0aHdheXNDYXNlX1YyLjQueHNkIiB4bWxucz0iaHR0cDovL25oc3BhdGh3YXlzLm9yZy93ZWJzZXJ2aWNlcy9wYXRod2F5cy9wYXRod2F5c0Nhc2UiPg0KCTxzZXJ2aWNlRGVzdGluYXRpb24+DQoJCTxuYW1lPkVNQVM8L25hbWU+DQoJCTxjb2RlLz4NCgk8L3NlcnZpY2VEZXN0aW5hdGlvbj4NCgk8bWVzc2FnZVN0YXR1cz5QYXJ0aWFsRXhwZWN0aW5nVXBkYXRlPC9tZXNzYWdlU3RhdHVzPg0KCTxjYXNlUmVjZWl2ZVN0YXJ0PjIwMTEtMDItMTdUMTc6Mjc6MzMuNzhaPC9jYXNlUmVjZWl2ZVN0YXJ0Pg0KCTxjYXNlUmVjZWl2ZUVuZD4yMDExLTAyLTE3VDE3OjMxOjE0LjMxM1o8L2Nhc2VSZWNlaXZlRW5kPg0KCTxvdXRjb21lPg0KCQk8dGl0bGU+RGlzcGF0Y2ggMTkgbWludXRlIGFtYnVsYW5jZTwvdGl0bGU+DQoJCTxjb2RlPkR4MDEyPC9jb2RlPg0KCTwvb3V0Y29tZT4NCgk8Y2FzZURldGFpbHM+DQoJCTxjYXNlUmVmPjMyODI5NjQzPC9jYXNlUmVmPg0KCQk8Y2FzZUlkPjgwNjdiOWIyLWU2MDQtNDQxNC1iNTZmLThlM2NjNGRlNGIxYjwvY2FzZUlkPg0KCQk8YWRkcmVzcz4NCgkJCTxidWlsZGluZy8+DQoJCQk8c3RyZWV0PnJlZGFjdGVkPC9zdHJlZXQ+DQoJCQk8bG9jYWxpdHkvPg0KCQkJPHRvd24+cmVkYWN0ZWQ8L3Rvd24+DQoJCQk8Y291bnR5PnJlZGFjdGVkPC9jb3VudHk+DQoJCQk8cG9zdGNvZGU+cmVkYWN0ZWQ8L3Bvc3Rjb2RlPg0KCQkJPG1hcFJlZj4NCgkJCQk8bG9uZ2l0dWRlLz4NCgkJCQk8bGF0aXR1ZGUvPg0KCQkJPC9tYXBSZWY+DQoJCQk8Y291bnRyeT4NCgkJCQk8bmFtZT5FbmdsYW5kPC9uYW1lPg0KCQkJCTxpc29BbHBoYTI+R0I8L2lzb0FscGhhMj4NCgkJCTwvY291bnRyeT4NCgkJCTxkaXJlY3Rpb25zLz4NCgkJPC9hZGRyZXNzPg0KCQk8Y29uZGl0aW9uLz4NCgkJPGNvbnRhY3REZXRhaWxzPg0KCQkJPGNhbGxlcj4NCgkJCQk8bmFtZS8+DQoJCQkJPHBob25lPg0KCQkJCQk8bnVtYmVyPnJlZGFjdGVkPC9udW1iZXI+DQoJCQkJCTxleHRlbnNpb24vPg0KCQkJCTwvcGhvbmU+DQoJCQk8L2NhbGxlcj4NCgkJPC9jb250YWN0RGV0YWlscz4NCgk8L2Nhc2VEZXRhaWxzPg0KCTxwYXRpZW50Pg0KCQk8Zm9yZW5hbWU+cmVkYWN0ZWQ8L2ZvcmVuYW1lPg0KCQk8c3VybmFtZT5yZWRhY3RlZDwvc3VybmFtZT4NCgkJPGFkZHJlc3M+DQoJCQk8YnVpbGRpbmcvPg0KCQkJPHN0cmVldD5yZWRhY3RlZDwvc3RyZWV0Pg0KCQkJPGxvY2FsaXR5Lz4NCgkJCTx0b3duPnJlZGFjdGVkPC90b3duPg0KCQkJPGNvdW50eT5yZWRhY3RlZDwvY291bnR5Pg0KCQkJPHBvc3Rjb2RlPnJlZGFjdGVkPC9wb3N0Y29kZT4NCgkJCTxtYXBSZWY+DQoJCQkJPGxvbmdpdHVkZS8+DQoJCQkJPGxhdGl0dWRlLz4NCgkJCTwvbWFwUmVmPg0KCQkJPGNvdW50cnk+DQoJCQkJPG5hbWU+RW5nbGFuZDwvbmFtZT4NCgkJCQk8aXNvQWxwaGEyPkdCPC9pc29BbHBoYTI+DQoJCQk8L2NvdW50cnk+DQoJCQk8ZGlyZWN0aW9ucy8+DQoJCTwvYWRkcmVzcz4NCgkJPHBob25lPg0KCQkJPG51bWJlcj5yZWRhY3RlZDwvbnVtYmVyPg0KCQkJPGV4dGVuc2lvbi8+DQoJCTwvcGhvbmU+DQoJCTxnZW5kZXI+TWFsZTwvZ2VuZGVyPg0KCQk8bmF0aW9uYWxOdW1iZXIvPg0KCQk8cHJvdmlkZXJEZXRhaWxzIHR5cGU9IkRPQ1RPUiI+DQoJCQk8cHJvdmlkZXI+DQoJCQkJPG5hbWUvPg0KCQkJCTxpZC8+DQoJCQk8L3Byb3ZpZGVyPg0KCQkJPHByb3ZpZGVyR3JvdXA+DQoJCQkJPG5hbWUvPg0KCQkJCTxpZC8+DQoJCQk8L3Byb3ZpZGVyR3JvdXA+DQoJCTwvcHJvdmlkZXJEZXRhaWxzPg0KCQk8ZGF0ZU9mQmlydGg+DQoJCQk8ZG9iPjIwMTAtMDYtMjM8L2RvYj4NCgkJPC9kYXRlT2ZCaXJ0aD4NCgkJPG1vYmlsZVBob25lLz4NCgk8L3BhdGllbnQ+DQoJPHJldHVyblBob25lPg0KCQk8bnVtYmVyPnJlZGFjdGVkPC9udW1iZXI+DQoJCTxleHRlbnNpb24vPg0KCTwvcmV0dXJuUGhvbmU+DQoJPGJpbGxpbmdBZGRyZXNzPg0KCQk8YnVpbGRpbmcvPg0KCQk8c3RyZWV0Lz4NCgkJPGxvY2FsaXR5Lz4NCgkJPHRvd24vPg0KCQk8Y291bnR5Lz4NCgkJPHBvc3Rjb2RlLz4NCgkJPG1hcFJlZj4NCgkJCTxsb25naXR1ZGUvPg0KCQkJPGxhdGl0dWRlLz4NCgkJPC9tYXBSZWY+DQoJCTxjb3VudHJ5Pg0KCQkJPG5hbWUvPg0KCQkJPGlzb0FscGhhMj5aWjwvaXNvQWxwaGEyPg0KCQk8L2NvdW50cnk+DQoJCTxkaXJlY3Rpb25zLz4NCgk8L2JpbGxpbmdBZGRyZXNzPg0KCTxwYXRod2F5RGV0YWlscz4NCgkJPHBhdGh3YXlUcmlhZ2VEZXRhaWxzPg0KCQkJPHBhdGh3YXlUcmlhZ2U+DQoJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6Mjc6MzMuNzhaPC9zdGFydD4NCgkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6MzE6MTQuMzEzWjwvZmluaXNoPg0KCQkJCTx0cmlhZ2VEaXNwb3NpdGlvbj4NCgkJCQkJPGluaXRpYWxEaXNwQ29kZT5EeDAxMjwvaW5pdGlhbERpc3BDb2RlPg0KCQkJCQk8aW5pdGlhbERpc3BUZXh0PkRpc3BhdGNoIDE5IG1pbnV0ZSBhbWJ1bGFuY2U8L2luaXRpYWxEaXNwVGV4dD4NCgkJCQkJPHRpbWVSZWFjaGVkPjIwMTEtMDItMTdUMTc6Mzk6MzYuNzQzWjwvdGltZVJlYWNoZWQ+DQoJCQkJPC90cmlhZ2VEaXNwb3NpdGlvbj4NCgkJCQk8ZmluYWxEaXNwb3NpdGlvbj4NCgkJCQkJPGZpbmFsRGlzcENvZGU+RHgwMTI8L2ZpbmFsRGlzcENvZGU+DQoJCQkJCTxmaW5hbERpc3B0ZXh0PkRpc3BhdGNoIDE5IG1pbnV0ZSBhbWJ1bGFuY2U8L2ZpbmFsRGlzcHRleHQ+DQoJCQkJPC9maW5hbERpc3Bvc2l0aW9uPg0KCQkJCTx0cmFuc2ZlckNvZGVEZXRhaWxzPg0KCQkJCQk8dHJhbnNmZXJDb2RlIHR5cGU9IlQxIi8+DQoJCQkJPC90cmFuc2ZlckNvZGVEZXRhaWxzPg0KCQkJCTx1c2VyPg0KCQkJCQk8aWQ+MzEzNzwvaWQ+DQoJCQkJCTxuYW1lPnJlZGFjdGVkPC9uYW1lPg0KCQkJCQk8c2tpbGxTZXQ+VDE8L3NraWxsU2V0Pg0KCQkJCTwvdXNlcj4NCgkJCQk8dHJpYWdlTGluZURldGFpbHM+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6Mjc6MzMuNzk3Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6Mjc6MzMuNzk3WjwvZmluaXNoPg0KCQkJCQkJPHF1ZXN0aW9uVHlwZT5TZXRWYXJpYWJsZTwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQvPg0KCQkJCQkJCQk8cGF0aHdheU9yZGVyTm8+MDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkLz4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0Lz4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dC8+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0vPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+UGF0aWVudDogIHJlZGFjdGVkICByZWRhY3RlZCwgQWdlIEdlbmRlciBTZWxlY3RlZDogcmVkYWN0ZWQgLCByZWRhY3RlZCAsIHJlZGFjdGVkPC90ZXh0Pg0KCQkJCQkJCTxwb3NpdGl2ZT5mYWxzZTwvcG9zaXRpdmU+DQoJCQkJCQk8L3JlcG9ydFRleHQ+DQoJCQkJCQk8dXNlckNvbW1lbnQvPg0KCQkJCQkJPGFjdGlvbj5CYWNrPC9hY3Rpb24+DQoJCQkJCQk8aW5jbHVkZUluUmVwb3J0PmZhbHNlPC9pbmNsdWRlSW5SZXBvcnQ+DQoJCQkJCTwvdHJpYWdlTGluZT4NCgkJCQkJPHRyaWFnZUxpbmU+DQoJCQkJCQk8c3RhcnQ+MjAxMS0wMi0xN1QxNzoyNzozMy43OTdaPC9zdGFydD4NCgkJCQkJCTxmaW5pc2g+MjAxMS0wMi0xN1QxNzoyNzozMy43OTdaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlBhdGh3YXlzU2VsZWN0aW9uPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjA8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZC8+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dC8+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQvPg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtLz4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PlBhdGh3YXkgU2VsZWN0ZWQ6IFBNSSwgQ2FsbGluZyBBYm91dCBTb21lb25lIGVsc2U8L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPmZhbHNlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPkJhY2s8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+ZmFsc2U8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJCTxzeXN0ZW1GbGFncz4NCgkJCQkJCQk8c3lzdGVtRmxhZz5UcmFwcGVkPC9zeXN0ZW1GbGFnPg0KCQkJCQkJPC9zeXN0ZW1GbGFncz4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjI3OjMzLjg2Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6Mjg6MDEuNVo8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjU8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZD5UeDIyMDEwOTwvcXVlc3Rpb25JZD4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PldoYXQgaXMgdGhlIHJlYXNvbiBmb3IgdGhlIGNhbGw/PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD5hbiBpbmp1cnkgb3Igb3RoZXIgaGVhbHRoIHByb2JsZW08L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PmEgbmVlZCB0byBhY2Nlc3MgYW5vdGhlciBoZWFsdGhjYXJlIHByb3ZpZGVyPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5hIGhlYWx0aGNhcmUgcHJvZmVzc2lvbmFsIHJlcXVlc3RpbmcgY29udGFjdCB3aXRoIGFub3RoZXIgY2xpbmljaWFuPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5hIHJlcG9ydCBvZiByZXN1bHRzIG9yIHRlc3RzPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5tb3JlPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtPklsbG5lc3Mgb3IgaW5qdXJ5PC90ZXJtPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+QW4gaW5qdXJ5IG9yIG90aGVyIGhlYWx0aCBwcm9ibGVtIHdhcyBkZXNjcmliZWQuPC90ZXh0Pg0KCQkJCQkJCTxwb3NpdGl2ZT50cnVlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPkJhY2s8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+ZmFsc2U8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjI4OjAxLjU2M1o8L3N0YXJ0Pg0KCQkJCQkJPGZpbmlzaD4yMDExLTAyLTE3VDE3OjI4OjA2LjMxM1o8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjM1PC9wYXRod2F5T3JkZXJObz4NCgkJCQkJCQk8L3RyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uSWQ+VHgxNDAxMTg8L3F1ZXN0aW9uSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dD5IYXMgdGhlIGJhYnkganVzdCBiZWVuIGJvcm4/PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+eWVzPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5ub3Qgc3VyZTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD5ubzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQk8L2Fuc3dlcnM+DQoJCQkJCQkJPGRpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJCQk8dGVybS8+DQoJCQkJCQkJCTxjb2RlLz4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dD5UaGUgYmFieSB3YXMgbW9yZSB0aGFuIG9uZSBob3VyIG9sZC48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPnRydWU8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Lz4NCgkJCQkJCTxhY3Rpb24+QmFjazwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD5mYWxzZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6Mjg6MDYuMzczWjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6Mjg6MDcuODZaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlNpbmdsZUFuc3dlcjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UE1JPC9wYXRod2F5SWQ+DQoJCQkJCQkJCTxwYXRod2F5T3JkZXJObz40MDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkPlR4MjIwMTEwPC9xdWVzdGlvbklkPg0KCQkJCQkJCTxxdWVzdGlvblRleHQ+SXMgaGUgYnJlYXRoaW5nIGFuZCBjb25zY2lvdXM/PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD5icmVhdGhpbmcgQU5EIGNvbnNjaW91czwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+YnJlYXRoaW5nIGJ1dCBOT1QgY29uc2Npb3VzIChpbmNsdWRlcyBjdXJyZW50IGZpdHRpbmcpPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5OT1QgYnJlYXRoaW5nPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5jaG9raW5nIG5vdzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQk8L2Fuc3dlcnM+DQoJCQkJCQkJPGRpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJCQk8dGVybT5CcmVhdGhpbmcgYW5kIGNvbnNjaW91czwvdGVybT4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PlRoZSBpbmRpdmlkdWFsIHdhcyBkZXNjcmliZWQgYXMgYnJlYXRoaW5nIGFuZCBjb25zY2lvdXMuPC90ZXh0Pg0KCQkJCQkJCTxwb3NpdGl2ZT50cnVlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPkJhY2s8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+ZmFsc2U8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjI4OjA3LjkyM1o8L3N0YXJ0Pg0KCQkJCQkJPGZpbmlzaD4yMDExLTAyLTE3VDE3OjI4OjIyLjA2M1o8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjYwPC9wYXRod2F5T3JkZXJObz4NCgkJCQkJCQk8L3RyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uSWQ+VHgyMjAyODU8L3F1ZXN0aW9uSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dD5IYXMgaGUgYmVlbiBibGVlZGluZyB2ZXJ5IGhlYXZpbHkgSU4gVEhFIExBU1QgSE9VUj88L3F1ZXN0aW9uVGV4dD4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5ibG9vZCBzcHVydGluZyBmcm9tIGEgd291bmQ8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PmFuIGVnZyBjdXBmdWwgb3IgbW9yZSBvZiByZWQgYmxvb2QgZnJvbSBhIGJvZHkgb3BlbmluZzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+YW4gZWdnIGN1cGZ1bCBvciBtb3JlIGZyb20gYSB3b3VuZDwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+bm90IHN1cmU8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9InRydWUiPg0KCQkJCQkJCQkJPHRleHQ+bm88L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0vPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+TWFqb3IgYmxvb2QgbG9zcyB3YXMgbm90IGRlc2NyaWJlZC48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPmZhbHNlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPkNoYW5nZTwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD5mYWxzZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6Mjg6MjIuNDdaPC9zdGFydD4NCgkJCQkJCTxmaW5pc2g+MjAxMS0wMi0xN1QxNzoyODoyMi40N1o8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjIwNTA8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZC8+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dD5Tb2NpYWxDb25jZXJuc0V4Y2x1ZGVkPC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+PT0icHJlc2VudCI8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9InRydWUiPg0KCQkJCQkJCQkJPHRleHQ+KjwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQk8L2Fuc3dlcnM+DQoJCQkJCQkJPGRpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJCQk8dGVybS8+DQoJCQkJCQkJCTxjb2RlLz4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dC8+DQoJCQkJCQkJPHBvc2l0aXZlPnRydWU8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Lz4NCgkJCQkJCTxhY3Rpb24+Q2hhbmdlPC9hY3Rpb24+DQoJCQkJCQk8aW5jbHVkZUluUmVwb3J0PmZhbHNlPC9pbmNsdWRlSW5SZXBvcnQ+DQoJCQkJCTwvdHJpYWdlTGluZT4NCgkJCQkJPHRyaWFnZUxpbmU+DQoJCQkJCQk8c3RhcnQ+MjAxMS0wMi0xN1QxNzozMDo0MS40ODNaPC9zdGFydD4NCgkJCQkJCTxmaW5pc2g+MjAxMS0wMi0xN1QxNzozMDo0Ni41WjwvZmluaXNoPg0KCQkJCQkJPHF1ZXN0aW9uVHlwZT5TaW5nbGVBbnN3ZXI8L3F1ZXN0aW9uVHlwZT4NCgkJCQkJCTxxdWVzdGlvbj4NCgkJCQkJCQk8dHJpYWdlTG9naWNJZD4NCgkJCQkJCQkJPHBhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQkJPG1ham9yPjY8L21ham9yPg0KCQkJCQkJCQkJPG1pbm9yPjI8L21pbm9yPg0KCQkJCQkJCQkJPHN1YlJldmlzaW9uPjE8L3N1YlJldmlzaW9uPg0KCQkJCQkJCQk8L3BhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQk8cGF0aHdheUlkPlBFRTM8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjA8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZD5UeDE0MDE1OTwvcXVlc3Rpb25JZD4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PldoYXQgaXMgdGhlIHJlYXNvbiBmb3IgZW5kaW5nIHRoZSBhc3Nlc3NtZW50PzwvcXVlc3Rpb25UZXh0Pg0KCQkJCQkJCTxxdWVzdGlvblJhdGlvbmFsZS8+DQoJCQkJCQkJPGFuc3dlcnM+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PnRoZSBwaG9uZSBsaW5lIHdlbnQgZGVhZDwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+dGhlIGNhbGxlciB0ZXJtaW5hdGVkIHRoZSBjYWxsIChzcGVjaWZ5KTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+SSB0ZXJtaW5hdGVkIHRoZSBjYWxsIChzcGVjaWZ5KTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+dHJpYWdlIG5vdCBwb3NzaWJsZTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD50cmFuc2ZlciB0byBhIGNsaW5pY2lhbjwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQk8L2Fuc3dlcnM+DQoJCQkJCQkJPGRpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJCQk8dGVybT5DYWxsIHRyYW5zZmVycmVkIGZvciBjbGluaWNpYW4gYXNzZXNzbWVudDwvdGVybT4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PkFzc2Vzc21lbnQgZW5kZWQgYmVjYXVzZSB0aGUgY2FsbCByZXF1aXJlZCB0cmFuc2ZlciB0byBhIGNsaW5pY2lhbi48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPmZhbHNlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPkVhcmx5RXhpdDwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD5mYWxzZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6MzA6NDYuNTc3Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6MzE6MDkuMTRaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlNpbmdsZUFuc3dlcjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UEVFMzwvcGF0aHdheUlkPg0KCQkJCQkJCQk8cGF0aHdheU9yZGVyTm8+NTA8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZD5UeDIyMDQwODwvcXVlc3Rpb25JZD4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PldIQVQgSVMgVEhFIFJFQVNPTiBGT1IgVFJBTlNGRVIgVE8gQSBDTElOSUNJQU4/PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+Y2FsbGVyIHJlZnVzZXMgZGlzcG9zaXRpb248L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0Pm11bHRpcGxlIHVucmVsYXRlZCBzeW1wdG9tczwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+ZGlmZmljdWx0eSBvYnRhaW5pbmcgYWRlcXVhdGUgaW5mb3JtYXRpb248L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0Pm1lZGljYXRpb24gb3IgbWVkaWNhbCBwcm9jZWR1cmUgZW5xdWlyeTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+ZGVjbGFyZWQgbWVkaWNhbCBoaXN0b3J5IChkZXRhaWxzIG5vdCByZXF1aXJlZCk8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9InRydWUiPg0KCQkJCQkJCQkJPHRleHQ+b3RoZXIgY29tcGxleCBjYWxsIChzcGVjaWZ5KTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQk8L2Fuc3dlcnM+DQoJCQkJCQkJPGRpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJCQk8dGVybS8+DQoJCQkJCQkJCTxjb2RlLz4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dD5UaGUgcmVhc29uIGZvciB0cmFuc2ZlciB0byBhIGNsaW5pY2lhbiB3YXM6IG90aGVyIGNvbXBsZXggY2FsbC48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPnRydWU8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Pk5FRURTIEZVUlRIRVIgQVNTRVNTTUVOVDwvdXNlckNvbW1lbnQ+DQoJCQkJCQk8YWN0aW9uPkJhY2s8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+ZmFsc2U8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjMxOjA5LjIzM1o8L3N0YXJ0Pg0KCQkJCQkJPGZpbmlzaD4yMDExLTAyLTE3VDE3OjMxOjExLjg5WjwvZmluaXNoPg0KCQkJCQkJPHF1ZXN0aW9uVHlwZT5EaXNwb3NpdGlvbjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UEVFMzwvcGF0aHdheUlkPg0KCQkJCQkJCQk8cGF0aHdheU9yZGVyTm8+MDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkLz4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PlNwZWFrIHRvIENsaW5pY2lhbiBmcm9tIG91ciBTZXJ2aWNlIGltbWVkaWF0ZWx5PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQvPg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtLz4NCgkJCQkJCQkJPGNvZGU+RHgzMjwvY29kZT4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dD5BIGNsaW5pY2lhbiBmcm9tIG91ciBzZXJ2aWNlIHdpbGwgY2FsbCB0aGUgaW5kaXZpZHVhbCBiYWNrIGltbWVkaWF0ZWx5IHRvIGFzc2VzcyB0aGUgcHJvYmxlbS48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPmZhbHNlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPlJlc3RhcnQ8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+ZmFsc2U8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjM1OjAzLjExN1o8L3N0YXJ0Pg0KCQkJCQkJPGZpbmlzaD4yMDExLTAyLTE3VDE3OjM1OjA4LjM2N1o8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2V0VmFyaWFibGU8L3F1ZXN0aW9uVHlwZT4NCgkJCQkJCTxxdWVzdGlvbj4NCgkJCQkJCQk8dHJpYWdlTG9naWNJZD4NCgkJCQkJCQkJPHBhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQkJPG1ham9yPjY8L21ham9yPg0KCQkJCQkJCQkJPG1pbm9yPjI8L21pbm9yPg0KCQkJCQkJCQkJPHN1YlJldmlzaW9uPjE8L3N1YlJldmlzaW9uPg0KCQkJCQkJCQk8L3BhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQk8cGF0aHdheUlkLz4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjA8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZC8+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dC8+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQvPg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtLz4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PlBhdGllbnQ6ICByZWRhY3RlZCByZWRhY3RlZCwgQWdlIEdlbmRlciBTZWxlY3RlZDogcmVkYWN0ZWQgLCByZWRhY3RlZCAsIHJlZGFjdGVkPC90ZXh0Pg0KCQkJCQkJCTxwb3NpdGl2ZT5mYWxzZTwvcG9zaXRpdmU+DQoJCQkJCQk8L3JlcG9ydFRleHQ+DQoJCQkJCQk8dXNlckNvbW1lbnQvPg0KCQkJCQkJPGFjdGlvbj5OZXh0PC9hY3Rpb24+DQoJCQkJCQk8aW5jbHVkZUluUmVwb3J0PnRydWU8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjM1OjAzLjExN1o8L3N0YXJ0Pg0KCQkJCQkJPGZpbmlzaD4yMDExLTAyLTE3VDE3OjM1OjA4LjM2N1o8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+UGF0aHdheXNTZWxlY3Rpb248L3F1ZXN0aW9uVHlwZT4NCgkJCQkJCTxxdWVzdGlvbj4NCgkJCQkJCQk8dHJpYWdlTG9naWNJZD4NCgkJCQkJCQkJPHBhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQkJPG1ham9yPjY8L21ham9yPg0KCQkJCQkJCQkJPG1pbm9yPjI8L21pbm9yPg0KCQkJCQkJCQkJPHN1YlJldmlzaW9uPjE8L3N1YlJldmlzaW9uPg0KCQkJCQkJCQk8L3BhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQk8cGF0aHdheUlkPlBNSTwvcGF0aHdheUlkPg0KCQkJCQkJCQk8cGF0aHdheU9yZGVyTm8+MDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkLz4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0Lz4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dC8+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0vPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+UGF0aHdheSBTZWxlY3RlZDogUE1JLCBDYWxsaW5nIEFib3V0IFNvbWVvbmUgZWxzZTwvdGV4dD4NCgkJCQkJCQk8cG9zaXRpdmU+ZmFsc2U8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Lz4NCgkJCQkJCTxhY3Rpb24+TmV4dDwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD50cnVlPC9pbmNsdWRlSW5SZXBvcnQ+DQoJCQkJCQk8c3lzdGVtRmxhZ3M+DQoJCQkJCQkJPHN5c3RlbUZsYWc+Q0FUQkxldmVsMzwvc3lzdGVtRmxhZz4NCgkJCQkJCTwvc3lzdGVtRmxhZ3M+DQoJCQkJCTwvdHJpYWdlTGluZT4NCgkJCQkJPHRyaWFnZUxpbmU+DQoJCQkJCQk8c3RhcnQ+MjAxMS0wMi0xN1QxNzozNTowOC40NDdaPC9zdGFydD4NCgkJCQkJCTxmaW5pc2g+MjAxMS0wMi0xN1QxNzozNToxMC42OFo8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjU8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZD5UeDIyMDEwOTwvcXVlc3Rpb25JZD4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PldoYXQgaXMgdGhlIHJlYXNvbiBmb3IgdGhlIGNhbGw/PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD5hbiBpbmp1cnkgb3Igb3RoZXIgaGVhbHRoIHByb2JsZW08L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PmEgbmVlZCB0byBhY2Nlc3MgYW5vdGhlciBoZWFsdGhjYXJlIHByb3ZpZGVyPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5hIGhlYWx0aGNhcmUgcHJvZmVzc2lvbmFsIHJlcXVlc3RpbmcgY29udGFjdCB3aXRoIGFub3RoZXIgY2xpbmljaWFuPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5hIHJlcG9ydCBvZiByZXN1bHRzIG9yIHRlc3RzPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5tb3JlPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtPklsbG5lc3Mgb3IgaW5qdXJ5PC90ZXJtPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+QW4gaW5qdXJ5IG9yIG90aGVyIGhlYWx0aCBwcm9ibGVtIHdhcyBkZXNjcmliZWQuPC90ZXh0Pg0KCQkJCQkJCTxwb3NpdGl2ZT50cnVlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPk5leHQ8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+dHJ1ZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6MzU6MTAuNzI3Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6MzU6MTIuODJaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlNpbmdsZUFuc3dlcjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UE1JPC9wYXRod2F5SWQ+DQoJCQkJCQkJCTxwYXRod2F5T3JkZXJObz4zNTwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkPlR4MTQwMTE4PC9xdWVzdGlvbklkPg0KCQkJCQkJCTxxdWVzdGlvblRleHQ+SGFzIHRoZSBiYWJ5IGp1c3QgYmVlbiBib3JuPzwvcXVlc3Rpb25UZXh0Pg0KCQkJCQkJCTxxdWVzdGlvblJhdGlvbmFsZS8+DQoJCQkJCQkJPGFuc3dlcnM+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PnllczwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+bm90IHN1cmU8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9InRydWUiPg0KCQkJCQkJCQkJPHRleHQ+bm88L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0vPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+VGhlIGJhYnkgd2FzIG1vcmUgdGhhbiBvbmUgaG91ciBvbGQuPC90ZXh0Pg0KCQkJCQkJCTxwb3NpdGl2ZT50cnVlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPk5leHQ8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+dHJ1ZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6MzU6MTIuODY3Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6MzU6MTQuNzI3WjwvZmluaXNoPg0KCQkJCQkJPHF1ZXN0aW9uVHlwZT5TaW5nbGVBbnN3ZXI8L3F1ZXN0aW9uVHlwZT4NCgkJCQkJCTxxdWVzdGlvbj4NCgkJCQkJCQk8dHJpYWdlTG9naWNJZD4NCgkJCQkJCQkJPHBhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQkJPG1ham9yPjY8L21ham9yPg0KCQkJCQkJCQkJPG1pbm9yPjI8L21pbm9yPg0KCQkJCQkJCQkJPHN1YlJldmlzaW9uPjE8L3N1YlJldmlzaW9uPg0KCQkJCQkJCQk8L3BhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQk8cGF0aHdheUlkPlBNSTwvcGF0aHdheUlkPg0KCQkJCQkJCQk8cGF0aHdheU9yZGVyTm8+NDA8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZD5UeDIyMDExMDwvcXVlc3Rpb25JZD4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PklzIGhlIGJyZWF0aGluZyBhbmQgY29uc2Npb3VzPzwvcXVlc3Rpb25UZXh0Pg0KCQkJCQkJCTxxdWVzdGlvblJhdGlvbmFsZS8+DQoJCQkJCQkJPGFuc3dlcnM+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9InRydWUiPg0KCQkJCQkJCQkJPHRleHQ+YnJlYXRoaW5nIEFORCBjb25zY2lvdXM8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PmJyZWF0aGluZyBidXQgTk9UIGNvbnNjaW91cyAoaW5jbHVkZXMgY3VycmVudCBmaXR0aW5nKTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+Tk9UIGJyZWF0aGluZzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+Y2hva2luZyBub3c8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0+QnJlYXRoaW5nIGFuZCBjb25zY2lvdXM8L3Rlcm0+DQoJCQkJCQkJCTxjb2RlLz4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dD5UaGUgaW5kaXZpZHVhbCB3YXMgZGVzY3JpYmVkIGFzIGJyZWF0aGluZyBhbmQgY29uc2Npb3VzLjwvdGV4dD4NCgkJCQkJCQk8cG9zaXRpdmU+dHJ1ZTwvcG9zaXRpdmU+DQoJCQkJCQk8L3JlcG9ydFRleHQ+DQoJCQkJCQk8dXNlckNvbW1lbnQvPg0KCQkJCQkJPGFjdGlvbj5OZXh0PC9hY3Rpb24+DQoJCQkJCQk8aW5jbHVkZUluUmVwb3J0PnRydWU8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjM1OjE0Ljc3M1o8L3N0YXJ0Pg0KCQkJCQkJPGZpbmlzaD4yMDExLTAyLTE3VDE3OjM1OjU2Ljk3N1o8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjYwPC9wYXRod2F5T3JkZXJObz4NCgkJCQkJCQk8L3RyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uSWQ+VHgyMjAyODU8L3F1ZXN0aW9uSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dD5IYXMgaGUgYmVlbiBibGVlZGluZyB2ZXJ5IGhlYXZpbHkgSU4gVEhFIExBU1QgSE9VUj88L3F1ZXN0aW9uVGV4dD4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5ibG9vZCBzcHVydGluZyBmcm9tIGEgd291bmQ8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PmFuIGVnZyBjdXBmdWwgb3IgbW9yZSBvZiByZWQgYmxvb2QgZnJvbSBhIGJvZHkgb3BlbmluZzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD5hbiBlZ2cgY3VwZnVsIG9yIG1vcmUgZnJvbSBhIHdvdW5kPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5ub3Qgc3VyZTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+bm88L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0+TWFqb3IgYmxvb2QgbG9zcywgd291bmQ8L3Rlcm0+DQoJCQkJCQkJCTxjb2RlLz4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dD5NYWpvciBibG9vZCBsb3NzIGZyb20gYSB3b3VuZCB3YXMgZGVzY3JpYmVkLjwvdGV4dD4NCgkJCQkJCQk8cG9zaXRpdmU+dHJ1ZTwvcG9zaXRpdmU+DQoJCQkJCQk8L3JlcG9ydFRleHQ+DQoJCQkJCQk8dXNlckNvbW1lbnQvPg0KCQkJCQkJPGFjdGlvbj5OZXh0PC9hY3Rpb24+DQoJCQkJCQk8aW5jbHVkZUluUmVwb3J0PnRydWU8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjM1OjU3LjA0Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6MzU6NTkuMDFaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlNpbmdsZUFuc3dlcjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UE1JPC9wYXRod2F5SWQ+DQoJCQkJCQkJCTxwYXRod2F5T3JkZXJObz4yMDAwMDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkPlR4MTQwMTA5PC9xdWVzdGlvbklkPg0KCQkJCQkJCTxxdWVzdGlvblRleHQ+SXMgaGUgZmlnaHRpbmcgZGVzcGVyYXRlbHkgZm9yIGV2ZXJ5IGJyZWF0aD88L3F1ZXN0aW9uVGV4dD4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD55ZXM8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0Pm5vdCBzdXJlPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJ0cnVlIj4NCgkJCQkJCQkJCTx0ZXh0Pm5vPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtLz4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PkZpZ2h0aW5nIGZvciBicmVhdGggd2FzIG5vdCBkZXNjcmliZWQuPC90ZXh0Pg0KCQkJCQkJCTxwb3NpdGl2ZT5mYWxzZTwvcG9zaXRpdmU+DQoJCQkJCQk8L3JlcG9ydFRleHQ+DQoJCQkJCQk8dXNlckNvbW1lbnQvPg0KCQkJCQkJPGFjdGlvbj5OZXh0PC9hY3Rpb24+DQoJCQkJCQk8aW5jbHVkZUluUmVwb3J0PnRydWU8L2luY2x1ZGVJblJlcG9ydD4NCgkJCQkJPC90cmlhZ2VMaW5lPg0KCQkJCQk8dHJpYWdlTGluZT4NCgkJCQkJCTxzdGFydD4yMDExLTAyLTE3VDE3OjM1OjU5LjA1N1o8L3N0YXJ0Pg0KCQkJCQkJPGZpbmlzaD4yMDExLTAyLTE3VDE3OjM2OjE2LjUyM1o8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjIwNDAwPC9wYXRod2F5T3JkZXJObz4NCgkJCQkJCQk8L3RyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uSWQ+VHgyMjA1NjM8L3F1ZXN0aW9uSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dD5JcyBoZSBsaW1wLCBmbG9wcHkgYW5kL29yIHVucmVzcG9uc2l2ZT88L3F1ZXN0aW9uVGV4dD4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD55ZXM8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0Pm5vdCBzdXJlPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJ0cnVlIj4NCgkJCQkJCQkJCTx0ZXh0Pm5vPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtLz4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PlRoZSBjaGlsZCB3YXMgbm90IGRlc2NyaWJlZCBhcyBsaW1wLCBmbG9wcHkgYW5kL29yIHVucmVzcG9uc2l2ZS48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPmZhbHNlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPk5leHQ8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+dHJ1ZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6MzY6MTYuNTg3Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6MzY6MTkuMzgzWjwvZmluaXNoPg0KCQkJCQkJPHF1ZXN0aW9uVHlwZT5TaW5nbGVBbnN3ZXI8L3F1ZXN0aW9uVHlwZT4NCgkJCQkJCTxxdWVzdGlvbj4NCgkJCQkJCQk8dHJpYWdlTG9naWNJZD4NCgkJCQkJCQkJPHBhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQkJPG1ham9yPjY8L21ham9yPg0KCQkJCQkJCQkJPG1pbm9yPjI8L21pbm9yPg0KCQkJCQkJCQkJPHN1YlJldmlzaW9uPjE8L3N1YlJldmlzaW9uPg0KCQkJCQkJCQk8L3BhdGh3YXlWZXJzaW9uPg0KCQkJCQkJCQk8cGF0aHdheUlkPlBNSTwvcGF0aHdheUlkPg0KCQkJCQkJCQk8cGF0aHdheU9yZGVyTm8+MjA0NTA8L3BhdGh3YXlPcmRlck5vPg0KCQkJCQkJCTwvdHJpYWdlTG9naWNJZD4NCgkJCQkJCQk8cXVlc3Rpb25JZD5UeDIyMDU2MTwvcXVlc3Rpb25JZD4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PklzIGhlIHdhcm0gdG8gdG91Y2g/PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD55ZXM8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0Pm5vdCBzdXJlPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5ubzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+bm90IHNhZmUgdG8gdG91Y2g8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0+V2FybSB0byB0b3VjaDwvdGVybT4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PlRoZSBpbmRpdmlkdWFsIHdhcyBkZXNjcmliZWQgYXMgYmVpbmcgd2FybSB0byB0b3VjaC48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPnRydWU8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Lz4NCgkJCQkJCTxhY3Rpb24+TmV4dDwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD50cnVlPC9pbmNsdWRlSW5SZXBvcnQ+DQoJCQkJCTwvdHJpYWdlTGluZT4NCgkJCQkJPHRyaWFnZUxpbmU+DQoJCQkJCQk8c3RhcnQ+MjAxMS0wMi0xN1QxNzozNjoxOS40NzdaPC9zdGFydD4NCgkJCQkJCTxmaW5pc2g+MjAxMS0wMi0xN1QxNzozNjoyMi40NjNaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlNpbmdsZUFuc3dlcjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UE1JPC9wYXRod2F5SWQ+DQoJCQkJCQkJCTxwYXRod2F5T3JkZXJObz4yMDgwMDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkPlR4MTIwMDE5PC9xdWVzdGlvbklkPg0KCQkJCQkJCTxxdWVzdGlvblRleHQ+V2FzIHRoZSBpbmp1cnkgY2F1c2VkIGJ5IGFueSBvZiB0aGUgZm9sbG93aW5nPzwvcXVlc3Rpb25UZXh0Pg0KCQkJCQkJCTxxdWVzdGlvblJhdGlvbmFsZS8+DQoJCQkJCQkJPGFuc3dlcnM+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PmEgZ3Vuc2hvdDwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+YSBzdGFiYmluZzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+YmVpbmcgZWplY3RlZCBmcm9tIGEgdmVoaWNsZTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+bm90IHN1cmU8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9InRydWUiPg0KCQkJCQkJCQkJPHRleHQ+bm88L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0vPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+QSBndW5zaG90IG9yIHN0YWJiaW5nIGluanVyeSBvciBlamVjdGlvbiBmcm9tIGEgdmVoaWNsZSB3YXMgbm90IGRlc2NyaWJlZC48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPmZhbHNlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPk5leHQ8L2FjdGlvbj4NCgkJCQkJCTxpbmNsdWRlSW5SZXBvcnQ+dHJ1ZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6MzY6MjIuNTRaPC9zdGFydD4NCgkJCQkJCTxmaW5pc2g+MjAxMS0wMi0xN1QxNzozNjoyNS42NjdaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlNpbmdsZUFuc3dlcjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UE1JPC9wYXRod2F5SWQ+DQoJCQkJCQkJCTxwYXRod2F5T3JkZXJObz4yMzEwMDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkPlR4MjIwMjg2PC9xdWVzdGlvbklkPg0KCQkJCQkJCTxxdWVzdGlvblRleHQ+RElEIFRIRSBJTkpVUlkgSU5WT0xWRSBBTlkgT0YgVEhFIEZPTExPV0lORz88L3F1ZXN0aW9uVGV4dD4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5hIGZhbGwgb2YgNSBtZXRyZXMgb3IgbW9yZSAoc3BlY2lmeSk8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0Pm11bHRpcGxlIG1ham9yIGluanVyaWVzIChzcGVjaWZ5KTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+bWFqb3Igd291bmQgb3IgYW1wdXRhdGlvbiAtIG5vdCBqdXN0IGludm9sdmluZyBhIHNpbmdsZSBmaW5nZXIgb3IgdG9lIChzcGVjaWZ5KTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+YmVpbmcga25vY2tlZCBvdmVyIGJ5IGEgYmxhc3QgKHNwZWNpZnkpPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5ub3Qgc3VyZTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0idHJ1ZSI+DQoJCQkJCQkJCQk8dGV4dD5ubzwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQk8L2Fuc3dlcnM+DQoJCQkJCQkJPGRpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJCQk8dGVybS8+DQoJCQkJCQkJCTxjb2RlLz4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dD5BIG1ham9yIGZhbGwsIG11bHRpcGxlIG1ham9yIGluanVyaWVzLCBhIG1ham9yIHdvdW5kL2FtcHV0YXRpb24gb3IgYmxhc3QgaW5qdXJ5IHdlcmUgbm90IGRlc2NyaWJlZC48L3RleHQ+DQoJCQkJCQkJPHBvc2l0aXZlPmZhbHNlPC9wb3NpdGl2ZT4NCgkJCQkJCTwvcmVwb3J0VGV4dD4NCgkJCQkJCTx1c2VyQ29tbWVudC8+DQoJCQkJCQk8YWN0aW9uPkNoYW5nZTwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD5mYWxzZTwvaW5jbHVkZUluUmVwb3J0Pg0KCQkJCQk8L3RyaWFnZUxpbmU+DQoJCQkJCTx0cmlhZ2VMaW5lPg0KCQkJCQkJPHN0YXJ0PjIwMTEtMDItMTdUMTc6MzY6NTMuMDU3Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6Mzc6MDUuMThaPC9maW5pc2g+DQoJCQkJCQk8cXVlc3Rpb25UeXBlPlNpbmdsZUFuc3dlcjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UEVFMzwvcGF0aHdheUlkPg0KCQkJCQkJCQk8cGF0aHdheU9yZGVyTm8+MDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkPlR4MTQwMTU5PC9xdWVzdGlvbklkPg0KCQkJCQkJCTxxdWVzdGlvblRleHQ+V2hhdCBpcyB0aGUgcmVhc29uIGZvciBlbmRpbmcgdGhlIGFzc2Vzc21lbnQ/PC9xdWVzdGlvblRleHQ+DQoJCQkJCQkJPHF1ZXN0aW9uUmF0aW9uYWxlLz4NCgkJCQkJCQk8YW5zd2Vycz4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+dGhlIHBob25lIGxpbmUgd2VudCBkZWFkPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD50aGUgY2FsbGVyIHRlcm1pbmF0ZWQgdGhlIGNhbGwgKHNwZWNpZnkpPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5JIHRlcm1pbmF0ZWQgdGhlIGNhbGwgKHNwZWNpZnkpPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD50cmlhZ2Ugbm90IHBvc3NpYmxlPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJ0cnVlIj4NCgkJCQkJCQkJCTx0ZXh0PnRyYW5zZmVyIHRvIGEgY2xpbmljaWFuPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtPkNhbGwgdHJhbnNmZXJyZWQgZm9yIGNsaW5pY2lhbiBhc3Nlc3NtZW50PC90ZXJtPg0KCQkJCQkJCQk8Y29kZS8+DQoJCQkJCQkJPC9kaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCTwvcXVlc3Rpb24+DQoJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZC8+DQoJCQkJCQk8L2NhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCTxjbGluaWNhbEFyZWEvPg0KCQkJCQkJPHJlcG9ydFRleHQ+DQoJCQkJCQkJPHRleHQ+QXNzZXNzbWVudCBlbmRlZCBiZWNhdXNlIHRoZSBjYWxsIHJlcXVpcmVkIHRyYW5zZmVyIHRvIGEgY2xpbmljaWFuLjwvdGV4dD4NCgkJCQkJCQk8cG9zaXRpdmU+ZmFsc2U8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Lz4NCgkJCQkJCTxhY3Rpb24+RWFybHlFeGl0PC9hY3Rpb24+DQoJCQkJCQk8aW5jbHVkZUluUmVwb3J0PmZhbHNlPC9pbmNsdWRlSW5SZXBvcnQ+DQoJCQkJCTwvdHJpYWdlTGluZT4NCgkJCQkJPHRyaWFnZUxpbmU+DQoJCQkJCQk8c3RhcnQ+MjAxMS0wMi0xN1QxNzozODo1MS45NjNaPC9zdGFydD4NCgkJCQkJCTxmaW5pc2g+MjAxMS0wMi0xN1QxNzozODo1My44Mlo8L2ZpbmlzaD4NCgkJCQkJCTxxdWVzdGlvblR5cGU+U2luZ2xlQW5zd2VyPC9xdWVzdGlvblR5cGU+DQoJCQkJCQk8cXVlc3Rpb24+DQoJCQkJCQkJPHRyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJCTxwYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJCTxtYWpvcj42PC9tYWpvcj4NCgkJCQkJCQkJCTxtaW5vcj4yPC9taW5vcj4NCgkJCQkJCQkJCTxzdWJSZXZpc2lvbj4xPC9zdWJSZXZpc2lvbj4NCgkJCQkJCQkJPC9wYXRod2F5VmVyc2lvbj4NCgkJCQkJCQkJPHBhdGh3YXlJZD5QTUk8L3BhdGh3YXlJZD4NCgkJCQkJCQkJPHBhdGh3YXlPcmRlck5vPjIzMTAwPC9wYXRod2F5T3JkZXJObz4NCgkJCQkJCQk8L3RyaWFnZUxvZ2ljSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uSWQ+VHgyMjAyODY8L3F1ZXN0aW9uSWQ+DQoJCQkJCQkJPHF1ZXN0aW9uVGV4dD5ESUQgVEhFIElOSlVSWSBJTlZPTFZFIEFOWSBPRiBUSEUgRk9MTE9XSU5HPzwvcXVlc3Rpb25UZXh0Pg0KCQkJCQkJCTxxdWVzdGlvblJhdGlvbmFsZS8+DQoJCQkJCQkJPGFuc3dlcnM+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0PmEgZmFsbCBvZiA1IG1ldHJlcyBvciBtb3JlIChzcGVjaWZ5KTwvdGV4dD4NCgkJCQkJCQkJCTxyYXRpb25hbGUvPg0KCQkJCQkJCQk8L2Fuc3dlcj4NCgkJCQkJCQkJPGFuc3dlciBzZWxlY3RlZD0iZmFsc2UiPg0KCQkJCQkJCQkJPHRleHQ+bXVsdGlwbGUgbWFqb3IgaW5qdXJpZXMgKHNwZWNpZnkpPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5tYWpvciB3b3VuZCBvciBhbXB1dGF0aW9uIC0gbm90IGp1c3QgaW52b2x2aW5nIGEgc2luZ2xlIGZpbmdlciBvciB0b2UgKHNwZWNpZnkpPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dD5iZWluZyBrbm9ja2VkIG92ZXIgYnkgYSBibGFzdCAoc3BlY2lmeSk8L3RleHQ+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJCTxhbnN3ZXIgc2VsZWN0ZWQ9ImZhbHNlIj4NCgkJCQkJCQkJCTx0ZXh0Pm5vdCBzdXJlPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJ0cnVlIj4NCgkJCQkJCQkJCTx0ZXh0Pm5vPC90ZXh0Pg0KCQkJCQkJCQkJPHJhdGlvbmFsZS8+DQoJCQkJCQkJCTwvYW5zd2VyPg0KCQkJCQkJCTwvYW5zd2Vycz4NCgkJCQkJCQk8ZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQkJCTx0ZXJtLz4NCgkJCQkJCQkJPGNvZGUvPg0KCQkJCQkJCTwvZGlzcG9zaXRpb25SYXRpb25hbGU+DQoJCQkJCQk8L3F1ZXN0aW9uPg0KCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkRGV0YWlscz4NCgkJCQkJCQk8Y2FyZUFkdmljZUtleXdvcmQvPg0KCQkJCQkJPC9jYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQk8Y2xpbmljYWxBcmVhLz4NCgkJCQkJCTxyZXBvcnRUZXh0Pg0KCQkJCQkJCTx0ZXh0PkEgbWFqb3IgZmFsbCwgbXVsdGlwbGUgbWFqb3IgaW5qdXJpZXMsIGEgbWFqb3Igd291bmQvYW1wdXRhdGlvbiBvciBibGFzdCBpbmp1cnkgd2VyZSBub3QgZGVzY3JpYmVkLjwvdGV4dD4NCgkJCQkJCQk8cG9zaXRpdmU+ZmFsc2U8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Lz4NCgkJCQkJCTxhY3Rpb24+TmV4dDwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD50cnVlPC9pbmNsdWRlSW5SZXBvcnQ+DQoJCQkJCTwvdHJpYWdlTGluZT4NCgkJCQkJPHRyaWFnZUxpbmU+DQoJCQkJCQk8c3RhcnQ+MjAxMS0wMi0xN1QxNzozODo1My45Wjwvc3RhcnQ+DQoJCQkJCQk8ZmluaXNoPjIwMTEtMDItMTdUMTc6Mzk6MzYuNzQzWjwvZmluaXNoPg0KCQkJCQkJPHF1ZXN0aW9uVHlwZT5EaXNwb3NpdGlvbjwvcXVlc3Rpb25UeXBlPg0KCQkJCQkJPHF1ZXN0aW9uPg0KCQkJCQkJCTx0cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCQk8cGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCQk8bWFqb3I+NjwvbWFqb3I+DQoJCQkJCQkJCQk8bWlub3I+MjwvbWlub3I+DQoJCQkJCQkJCQk8c3ViUmV2aXNpb24+MTwvc3ViUmV2aXNpb24+DQoJCQkJCQkJCTwvcGF0aHdheVZlcnNpb24+DQoJCQkJCQkJCTxwYXRod2F5SWQ+UE1JPC9wYXRod2F5SWQ+DQoJCQkJCQkJCTxwYXRod2F5T3JkZXJObz4yNDEwMDwvcGF0aHdheU9yZGVyTm8+DQoJCQkJCQkJPC90cmlhZ2VMb2dpY0lkPg0KCQkJCQkJCTxxdWVzdGlvbklkLz4NCgkJCQkJCQk8cXVlc3Rpb25UZXh0PkRpc3BhdGNoIDE5IG1pbnV0ZSBhbWJ1bGFuY2U8L3F1ZXN0aW9uVGV4dD4NCgkJCQkJCQk8cXVlc3Rpb25SYXRpb25hbGUvPg0KCQkJCQkJCTxhbnN3ZXJzPg0KCQkJCQkJCQk8YW5zd2VyIHNlbGVjdGVkPSJmYWxzZSI+DQoJCQkJCQkJCQk8dGV4dC8+DQoJCQkJCQkJCQk8cmF0aW9uYWxlLz4NCgkJCQkJCQkJPC9hbnN3ZXI+DQoJCQkJCQkJPC9hbnN3ZXJzPg0KCQkJCQkJCTxkaXNwb3NpdGlvblJhdGlvbmFsZT4NCgkJCQkJCQkJPHRlcm0vPg0KCQkJCQkJCQk8Y29kZT5EeDAxMjwvY29kZT4NCgkJCQkJCQk8L2Rpc3Bvc2l0aW9uUmF0aW9uYWxlPg0KCQkJCQkJPC9xdWVzdGlvbj4NCgkJCQkJCTxjYXJlQWR2aWNlS2V5d29yZERldGFpbHM+DQoJCQkJCQkJPGNhcmVBZHZpY2VLZXl3b3JkLz4NCgkJCQkJCTwvY2FyZUFkdmljZUtleXdvcmREZXRhaWxzPg0KCQkJCQkJPGNsaW5pY2FsQXJlYS8+DQoJCQkJCQk8cmVwb3J0VGV4dD4NCgkJCQkJCQk8dGV4dD5BbiBlbWVyZ2VuY3kgYW1idWxhbmNlIGlzIGJlaW5nIGFycmFuZ2VkLjwvdGV4dD4NCgkJCQkJCQk8cG9zaXRpdmU+ZmFsc2U8L3Bvc2l0aXZlPg0KCQkJCQkJPC9yZXBvcnRUZXh0Pg0KCQkJCQkJPHVzZXJDb21tZW50Lz4NCgkJCQkJCTxhY3Rpb24+TmV4dDwvYWN0aW9uPg0KCQkJCQkJPGluY2x1ZGVJblJlcG9ydD50cnVlPC9pbmNsdWRlSW5SZXBvcnQ+DQoJCQkJCTwvdHJpYWdlTGluZT4NCgkJCQk8L3RyaWFnZUxpbmVEZXRhaWxzPg0KCQkJCTxvcmlnU2l0ZT4NCgkJCQkJPHNpdGVJZD40PC9zaXRlSWQ+DQoJCQkJCTxzaXRlTmFtZT5EdWRsZXk8L3NpdGVOYW1lPg0KCQkJCQk8Y2FzZUlkPjgwNjdiOWIyLWU2MDQtNDQxNC1iNTZmLThlM2NjNGRlNGIxYjwvY2FzZUlkPg0KCQkJCQk8cGF0aHdheXNDb250ZW50VmVyc2lvbj42LjIuMWhOSFNEPC9wYXRod2F5c0NvbnRlbnRWZXJzaW9uPg0KCQkJCQk8c29mdHdhcmU+DQoJCQkJCQk8cHJvZHVjdE5hbWU+Q0FTIEZyYW1ld29yazwvcHJvZHVjdE5hbWU+DQoJCQkJCQk8dmVyc2lvbj5WMTIuMjwvdmVyc2lvbj4NCgkJCQkJPC9zb2Z0d2FyZT4NCgkJCQk8L29yaWdTaXRlPg0KCQkJCTxjYWxsZXJJc1BhdGllbnQ+ZmFsc2U8L2NhbGxlcklzUGF0aWVudD4NCgkJCTwvcGF0aHdheVRyaWFnZT4NCgkJPC9wYXRod2F5VHJpYWdlRGV0YWlscz4NCgkJPGRlbW9ncmFwaGljcz4NCgkJCTxnZW5kZXI+TWFsZTwvZ2VuZGVyPg0KCQkJPGFnZUdyb3VwPkFkdWx0PC9hZ2VHcm91cD4NCgkJPC9kZW1vZ3JhcGhpY3M+DQoJCTxzaGFyZWRDYXNlSWQvPg0KCTwvcGF0aHdheURldGFpbHM+DQoJPHNpdGU+DQoJCTxpZD40PC9pZD4NCgkJPG5hbWU+RHVkbGV5PC9uYW1lPg0KCTwvc2l0ZT4NCjwvUGF0aHdheXNDYXNlPg0K
+                                                </value>
+                                                <participant typeCode="DEV" contextControlCode="OP">
+                                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                extension="COCD_TP146002GB01#participant"/>
+                                                    <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                                       extension="COCD_TP145000GB01#ParticipantRole"/>
+                                                    <participantRole classCode="ROL">
+                                                        <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                    extension="COCD_TP145000GB01#ParticipantRole"/>
+                                                        <code code="TS"
+                                                              codeSystem="2.16.840.1.113883.2.1.3.2.4.17.418"/>
+                                                        <playingDevice classCode="DEV" determinerCode="INSTANCE">
+                                                            <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                        extension="COCD_TP145000GB01#playingDevice"/>
+                                                            <manufacturerModelName displayName="Pathways"/>
+                                                            <softwareName displayName="2.4"/>
+                                                        </playingDevice>
+                                                    </participantRole>
+                                                </participant>
+                                            </observationMedia>
+                                        </entry>
+                                        <entry typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146050GB01#PermissionToView"/>
+                                            <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146050GB01#PermissionToView"/>
+                                                <code code="PTV" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.220"/>
+                                                <effectiveTime>
+                                                    <low value="201105192000+00"/>
+                                                    <high value="201105262000+00"/>
+                                                </effectiveTime>
+                                                <value xsi:type="CV" code="01"
+                                                       codeSystem="2.16.840.1.113883.2.1.3.2.4.17.524"/>
+                                            </observation>
+                                        </entry>
+                                        <entry typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146092GB01#ClinicalDiscriminator"/>
+                                            <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146092GB01#ClinicalDiscriminator"/>
+                                                <code code="CD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.540"/>
+                                                <value xsi:type="CV" code="22298006"
+                                                       codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                       displayName="Myocardial infarction"/>
+                                            </observation>
+                                        </entry>
+                                        <entry typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146092GB01#ClinicalDiscriminator"/>
+                                            <observation classCode="OBS" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146092GB01#ClinicalDiscriminator"/>
+                                                <code code="CD" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.540"/>
+                                                <value xsi:type="CV" code="Dx011"
+                                                       codeSystem="2.16.840.1.113883.2.1.3.2.4.24"
+                                                       displayName="heart attack"/>
+                                            </observation>
+                                        </entry>
+                                        <entry typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146093GB01#AppointmentReference"/>
+                                            <encounter classCode="ENC" moodCode="APT">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146093GB01#AppointmentReference"/>
+                                                <id root="2.16.840.1.113883.2.1.3.2.4.17.541"
+                                                    extension="eb4f7f21-3962-4416-9a29-a46dd6ee5f17"/>
+                                                <code code="01" codeSystem="2.16.840.1.113883.2.1.3.2.4.17.542"
+                                                      displayName="Patient convenience appointment"/>
+                                                <effectiveTime value="201706011400+00"/>
+                                                <participant typeCode="LOC" contextControlCode="OP">
+                                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                extension="COCD_TP146093GB01#location"/>
+                                                    <participantRole classCode="ASSIGNED">
+                                                        <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                    extension="COCD_TP146093GB01#assignedEntity"/>
+                                                        <id root="2.16.840.1.113883.2.1.3.2.4.19.1" extension="Q36"/>
+                                                        <addr use="WP">
+                                                            <streetAddressLine>Great George Street</streetAddressLine>
+                                                            <city>Leeds</city>
+                                                            <postalCode>LE13EX</postalCode>
+                                                        </addr>
+                                                        <playingEntity classCode="ORG" determinerCode="INSTANCE">
+                                                            <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                        extension="COCD_TP146093GB01#assignedOrganization"/>
+                                                            <name>CENTRAL LONDON COMMUNITY HEALTHCARE NHS TRUST</name>
+                                                            <desc>Psychiatric Community Care Services</desc>
+                                                        </playingEntity>
+                                                    </participantRole>
+                                                </participant>
+                                            </encounter>
+                                        </entry>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="41D9F90F-6DB7-4939-BEF5-F8D75D79ECDD"/>
+                                                <code code="887031000000108" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Consent for information sharing"/>
+                                                <title>Permission to View</title>
+                                                <text>
+                                                    <table>
+                                                        <tbody>
+                                                            <tr>
+                                                                <th>Permission to view outcome</th>
+                                                                <td>Permission to view obtained</td>
+                                                            </tr>
+                                                            <tr>
+                                                                <th>Date obtained</th>
+                                                                <td>01-Jan-2017, 20:00</td>
+                                                            </tr>
+                                                            <tr>
+                                                                <th>Date expires</th>
+                                                                <td>15-Jan-2017, 20:00</td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </text>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="773110DB-288F-4B32-8DE1-362646A65E9A"/>
+                                                <code code="886891000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Presenting complaints or issues"/>
+                                                <title>Primary Reason for Call</title>
+                                                <text>
+                                                    <content>Patient feels dizzy.</content>
+                                                </text>
+                                                <component typeCode="COMP" contextConductionInd="true">
+                                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                extension="COCD_TP146246GB01#component1"/>
+                                                    <section classCode="DOCSECT" moodCode="EVN">
+                                                        <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                    extension="COCD_TP146246GB01#section2"/>
+                                                        <id root="BBC110DB-288F-4B32-8DE1-362646A65AAF"/>
+                                                        <title>SUBSUB2</title>
+                                                        <text>
+                                                            <content>SUBSUB2</content>
+                                                        </text>
+                                                        <component typeCode="COMP" contextConductionInd="true">
+                                                            <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                        extension="COCD_TP146246GB01#component2"/>
+                                                            <section classCode="DOCSECT" moodCode="EVN">
+
+                                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                            extension="COCD_TP146246GB01#section3"/>
+
+                                                                <id root="DDD110DB-288F-4B32-8DE1-362646A65DDD"/>
+                                                                <title>SUBSUB3</title>
+                                                                <text>
+                                                                    <content>SUBSUB3</content>
+                                                                </text>
+                                                            </section>
+                                                        </component>
+                                                    </section>
+                                                </component>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="8271D2F1-126F-4A14-A1AC-C6C8023243CF"/>
+                                                <code code="887181000000106" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Clinical summary"/>
+                                                <title>Clinical Summary</title>
+                                                <text>
+                                                    <content>
+                                                        Patient fels nausea and dizzy after waking up. Lasted 30
+                                                        minutes.
+                                                    </content>
+                                                </text>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="773110DB-288F-4B32-8531-362646A65E9B"/>
+                                                <code code="38651000000103" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Other note"/>
+                                                <title>Additional Patient Notes</title>
+                                                <text>
+                                                    Additional Patient Notes
+                                                    <br/>
+                                                    Additional Patient Notes abc 01-Feb-2017, 12:00
+                                                    <br/>
+                                                </text>
+                                                <component typeCode="COMP" contextConductionInd="true">
+                                                    <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                extension="COCD_TP146246GB01#component1"/>
+                                                    <section classCode="DOCSECT" moodCode="EVN">
+                                                        <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                                    extension="COCD_TP146246GB01#section2"/>
+                                                        <id root="773990DB-288F-4B32-8531-362646A65E9B"/>
+                                                        <text>These are more notes, nested under the top one.</text>
+                                                    </section>
+                                                </component>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="773110DB-288F-4B32-8CC1-362646665E9A"/>
+                                                <code code="913341000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Disposition details"/>
+                                                <title>Disposition Details</title>
+                                                <text>
+                                                    <content>Lie down.</content>
+                                                </text>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="773110DB-288F-4B32-8EB1-362646665E9A"/>
+                                                <code code="1052951000000105"
+                                                      codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Information and advice given"/>
+                                                <title>Information and advice given</title>
+                                                <text>
+                                                    <content>Do not perform any strenuous activities.</content>
+                                                </text>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="773110DB-288F-4B32-8A31-362646665E9A"/>
+                                                <code code="886921000000105" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Allergies and adverse reaction"/>
+                                                <title>Recorded Allergies</title>
+                                                <text>
+                                                    <content>No known allergies or adverse reaction.</content>
+                                                </text>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="773110DB-288F-4B32-8A94-362646665E9A"/>
+                                                <code code="4281000179108" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Triage form"/>
+                                                <title>Triage Report</title>
+                                                <text>
+                                                    <content>An injury or other health problem was described.
+                                                        <br/>The individual was described as breathing and conscious.
+                                                        <br/>Loss of at least a mugful of blood in the last 30 minutes
+                                                        was not described.
+                                                        <br/>An illness or other health problem was described. -
+                                                        Dizziness
+                                                        <br/>Fighting for breath was not described.
+                                                        <br/>A heart attack, chest/upper back pain, recent probable
+                                                        stroke, recent fit/seizure or suicide attempt was not described
+                                                        as the main call reason.
+                                                        <br/>Dizziness and nausea was described.
+                                                        <br/>
+                                                    </content>
+                                                </text>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="C3A0F8FB-35FA-4358-B46E-6F9EE6AC6CF2"/>
+                                                <code code="933361000000108" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Medications and medical devices"/>
+                                                <title>Prescribed Items</title>
+                                                <text>
+                                                    <content>
+                                                        Medications
+                                                    </content>
+                                                </text>
+                                            </section>
+                                        </component>
+                                        <component typeCode="COMP" contextConductionInd="true">
+                                            <npfitlc:contentId root="2.16.840.1.113883.2.1.3.2.4.18.16"
+                                                               extension="COCD_TP146246GB01#Section1"/>
+                                            <section classCode="DOCSECT" moodCode="EVN">
+                                                <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
+                                                            extension="COCD_TP146246GB01#Section1"/>
+                                                <id root="8271D2F1-126F-4A14-A1AC-C6C8023243FF"/>
+                                                <code code="749001000000101" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                                      displayName="Appointment"/>
+                                                <title>Appointment Reference</title>
+                                                <text>
+                                                    <content>
+                                                        Date/Time: 01 June 2017 14:00
+                                                        Location: CENTRAL LONDON COMMUNITY HEALTHCARE NHS TRUST
+                                                        Psychiatric Community Care Service
+                                                    </content>
+                                                </text>
+                                            </section>
+                                        </component>
+                                    </section>
+                                </component>
+                            </structuredBody>
+                        </component>
+                    </ClinicalDocument>
+                </itk:payload>
+            </itk:payloads>
+        </itk:DistributionEnvelope>
+    </s:Body>
+</s:Envelope>

--- a/test-suite/src/data/safeguarding-request.xml
+++ b/test-suite/src/data/safeguarding-request.xml
@@ -67,7 +67,7 @@
                                 <id extension="K12345" root="2.16.840.1.113883.2.1.3.2.4.18.24"
                                     assigningAuthorityName="Medway NHS Foundation Trust"/>
                                 <id extension="993254128" root="2.16.840.1.113883.2.1.3.2.4.18.23"/>
-                                <id extension="%NHS_NUMBER%" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
+                                <id extension="%NHS-NUMBER%" root="2.16.840.1.113883.2.1.4.1" xmlns:npfitlc="NPFIT:HL7:Localisation" />
                                 <addr use="H">
                                     <streetAddressLine>17, County Avenue</streetAddressLine>
                                     <streetAddressLine>Woodtown</streetAddressLine>
@@ -185,18 +185,18 @@
                                 <templateId extension="COCD_TP145203GB03#IntendedRecipient"
                                             root="2.16.840.1.113883.2.1.3.2.4.18.2"/>
                                 <addr use="WP">
-                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_LINE_1%</streetAddressLine>
-                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_LINE_2%</streetAddressLine>
-                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_TOWN%</streetAddressLine>
-                                    <streetAddressLine>%RECIPIENT_STREET_ADDRESS_CITY%</streetAddressLine>
-                                    <postalCode>%RECIPIENT_STREET_ADDRESS_POSTCODE%</postalCode>
+                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-LINE-1%</streetAddressLine>
+                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-LINE-2%</streetAddressLine>
+                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-TOWN%</streetAddressLine>
+                                    <streetAddressLine>%RECIPIENT-STREET-ADDRESS-CITY%</streetAddressLine>
+                                    <postalCode>%RECIPIENT-STREET-ADDRESS-POSTCODE%</postalCode>
                                 </addr>
                                 <telecom use="WP" value="tel:0123476895"/>
                                 <receivedOrganization classCode="ORG" determinerCode="INSTANCE">
                                     <templateId root="2.16.840.1.113883.2.1.3.2.4.18.2"
                                                 extension="COCD_TP145203GB03#representedOrganization"/>
                                     <id root="2.16.840.1.113883.2.1.3.2.4.19.2" extension="PRA123"/>
-                                    <name>%RECIPIENT_NAME%</name>
+                                    <name>%RECIPIENT-NAME%</name>
                                 </receivedOrganization>
                             </intendedRecipient>
                         </informationRecipient>

--- a/test-suite/src/data/schema.ts
+++ b/test-suite/src/data/schema.ts
@@ -115,6 +115,95 @@ const schema: Schema = {
             ],
           },
         },
+        {
+          testName: "Safeguarding referral",
+          testDescription: "This test will attempt to send notification of safeguarding referral to Social Services.",
+          template: require("./safeguarding-request.xml"),
+          testSpecifications: {
+            [RequestHeaderProps.Header]: [
+              {
+                label: "url",
+                id: "url",
+                defaultValue: "http://localhost:8081/report",
+                validators: [isLocalUrl(), isReportUrl()]
+              },
+              {
+                label: "Content Type",
+                id: "content-type",
+                defaultValue: "application/xml",
+                validators: [notNull(), minLength(7)]
+              }
+            ],
+            [RequestHeaderProps.Body]: [
+              {
+                label: "ODS Code",
+                id: "ods-code",
+                defaultValue: "EM396",
+                validators: [notNull()]
+              },
+              {
+                label: "DOS Code",
+                id: "dos-code",
+                defaultValue: "26428",
+                validators: []
+              },
+              {
+                label: "NHS Number",
+                id: "nhs-number",
+                defaultValue: "1717636608",
+                validators: [notNull(), isNumeric(), isLength(10)]
+              },
+              {
+                label: "Recipient Name",
+                id: "recipient-name",
+                defaultValue: "John Stones",
+                validators: [notNull()]
+              },
+              {
+                label: "Recipient Address Line 1",
+                id: "recipient-street-address-line-1",
+                defaultValue: "1 Albion Place",
+                validators: [notNull()]
+              },
+              {
+                label: "Recipient Address Line 2",
+                id: "recipient-street-address-line-2",
+                defaultValue: "Leeds City Centre",
+                validators: [notNull()]
+              },
+              {
+                label: "Recipient Town",
+                id: "recipient-street-address-town",
+                defaultValue: "",
+                validators: []
+              },
+              {
+                label: "Recipient City",
+                id: "recipient-street-address-city",
+                defaultValue: "Leeds",
+                validators: []
+              },
+              {
+                label: "Recipient Postcode",
+                id: "recipient-street-address-postcode",
+                defaultValue: "LS1 6LJ",
+                validators: []
+              },
+              {
+                label: "Encounter Start Datetime",
+                id: "nhs111-encounter-date-time-start",
+                defaultValue: "202205311539",
+                validators: [notNull(), isNumeric()]
+              },
+              {
+                label: "Encounter End Datetime",
+                id: "nhs111-encounter-date-time-end",
+                defaultValue: "202205311615",
+                validators: [notNull(), isNumeric()]
+              }
+            ]
+          }
+        }
       ],
     },
   ],

--- a/test-suite/src/data/schema.ts
+++ b/test-suite/src/data/schema.ts
@@ -194,13 +194,15 @@ const schema: Schema = {
                 label: "Encounter Start Datetime",
                 id: "nhs111-encounter-date-time-start",
                 defaultValue: "202205311539",
-                validators: [notNull(), isNumeric(), isLength(12)]
+                validators: [notNull(), isNumeric(), isLength(12)],
+                date: true
               },
               {
                 label: "Encounter End Datetime",
                 id: "nhs111-encounter-date-time-end",
                 defaultValue: "202205311615",
-                validators: [notNull(), isNumeric(), isLength(12)]
+                validators: [notNull(), isNumeric(), isLength(12)],
+                date: true
               }
             ]
           }

--- a/test-suite/src/data/schema.ts
+++ b/test-suite/src/data/schema.ts
@@ -7,6 +7,7 @@ import {
   minLength,
   notNull,
   isUrl,
+  isAlphanumeric
 } from "../utils/validators";
 
 /**
@@ -116,8 +117,8 @@ const schema: Schema = {
           },
         },
         {
-          testName: "Safeguarding referral",
-          testDescription: "This test will attempt to send notification of safeguarding referral to Social Services.",
+          testName: "Safeguarding Referral",
+          testDescription: "This test will attempt to send notification of a safeguarding referral to Social Services.",
           template: require("./safeguarding-request.xml"),
           testSpecifications: {
             [RequestHeaderProps.Header]: [
@@ -125,7 +126,7 @@ const schema: Schema = {
                 label: "url",
                 id: "url",
                 defaultValue: "http://localhost:8081/report",
-                validators: [isLocalUrl(), isReportUrl()]
+                validators: [isUrl(), isReportUrl()]
               },
               {
                 label: "Content Type",
@@ -139,13 +140,13 @@ const schema: Schema = {
                 label: "ODS Code",
                 id: "ods-code",
                 defaultValue: "EM396",
-                validators: [notNull()]
+                validators: [notNull(), isAlphanumeric()]
               },
               {
                 label: "DOS Code",
                 id: "dos-code",
                 defaultValue: "26428",
-                validators: []
+                validators: [isAlphanumeric()]
               },
               {
                 label: "NHS Number",
@@ -157,49 +158,49 @@ const schema: Schema = {
                 label: "Recipient Name",
                 id: "recipient-name",
                 defaultValue: "John Stones",
-                validators: [notNull()]
+                validators: [notNull(), isAlpha()]
               },
               {
                 label: "Recipient Address Line 1",
                 id: "recipient-street-address-line-1",
                 defaultValue: "1 Albion Place",
-                validators: [notNull()]
+                validators: [notNull(), isAlphanumeric()]
               },
               {
                 label: "Recipient Address Line 2",
                 id: "recipient-street-address-line-2",
                 defaultValue: "Leeds City Centre",
-                validators: [notNull()]
+                validators: [notNull(), isAlphanumeric()]
               },
               {
                 label: "Recipient Town",
                 id: "recipient-street-address-town",
                 defaultValue: "",
-                validators: []
+                validators: [isAlpha()]
               },
               {
                 label: "Recipient City",
                 id: "recipient-street-address-city",
                 defaultValue: "Leeds",
-                validators: []
+                validators: [isAlpha()]
               },
               {
                 label: "Recipient Postcode",
                 id: "recipient-street-address-postcode",
                 defaultValue: "LS1 6LJ",
-                validators: []
+                validators: [isAlphanumeric()]
               },
               {
                 label: "Encounter Start Datetime",
                 id: "nhs111-encounter-date-time-start",
                 defaultValue: "202205311539",
-                validators: [notNull(), isNumeric()]
+                validators: [notNull(), isNumeric(), isLength(12)]
               },
               {
                 label: "Encounter End Datetime",
                 id: "nhs111-encounter-date-time-end",
                 defaultValue: "202205311615",
-                validators: [notNull(), isNumeric()]
+                validators: [notNull(), isNumeric(), isLength(12)]
               }
             ]
           }

--- a/test-suite/src/types/index.ts
+++ b/test-suite/src/types/index.ts
@@ -84,7 +84,8 @@ export type ValidatorKeys =
   | "reportMatch"
   | "regexMatch"
   | "isLength"
-  | "numericMatch";
+  | "numericMatch"
+  | "alphaNumericMatch";
 
 export type FormErrors = {
   [key: string]: FormError | null;

--- a/test-suite/src/types/index.ts
+++ b/test-suite/src/types/index.ts
@@ -30,6 +30,7 @@ export type TestRequestField = {
   label: string;
   defaultValue: string;
   validators?: Array<Validator>;
+  date?: boolean;
   value?: string;
 };
 

--- a/test-suite/src/utils/validators.ts
+++ b/test-suite/src/utils/validators.ts
@@ -66,6 +66,13 @@ export const isAlpha = () =>
 export const isNumeric = () =>
   regexMatch(/^[0-9 ]*$/, "Field must be numeric", "numericMatch" as const);
 
+export const isAlphanumeric = () =>
+    regexMatch(
+        /^[A-Za-z0-9 ]*$/,
+        "Field must be alphanumeric",
+        "alphaNumericMatch" as const
+    );
+
 export const validateField = (fieldValidation: FormError, value: string) =>
   Object.entries(fieldValidation).reduce((acc, [k, v]) => {
     let isError = false;


### PR DESCRIPTION
### Scenario: 

PEM indicating that the call resulted in child safeguarding referral 

PEM indicating that the call resulted in  adult safeguarding referral

Disposition - [e.g Dx42 - immediate referral]



**GIVEN**  contact call to NHS 111

**WHEN** the call is triaged and disposition determined

**THEN** a PEM (for information) is sent to the patients GP with notification of Safeguarding referral to Social Services



Demographic info (via link) can be used to test vulnerable adult scenario: file:///Users/sheila.smith/Downloads/Integrated%20Urgent%20Care%20Report%20-%20EXAMPLE.html

 <address uri="urn:nhs-uk:addressing:ods: "EM396" />                         <address type="2.16.840.1.113883.2.1.3.2.4.18.44" uri="26428" />

### ACCEPTANCE CRITERIA

**GIVEN** a test user wants to test a Patient referred to Primary Care
**THEN** opening the test area the following form fields should be visible…

ODS Code - Id: @@ods-code@@, NOT NULL

DOS Code - Id: @@dos-code@@

NHS Number - Id: @@nhs-number@@ NOT NULL

Recipient Name: @@recipent-name@@ NOT NULL

Recipient Address Line 1: @@recipent-street-address-line-1@@ NOT NULL

Recipient Address Line 2: @@recipent-street-address-line-2@@ NOT NULL

Recipient Town: @@recipent-street-address-town@@ 

Recipient City: @@recipent-street-address-city@@ 

Recipient Postcode: @@recipent-street-address-postcode@@ 

Encounter Start Datetime: @@nhs111-encounter-date-time-start@@, NOT NULL

Encounter End Datetime: @@nhs111-encounter-date-time-end@@, NOT NULL

**WHEN** entered and validated 
**THEN** the fields should be inserted into the example data given below
**AND** a request should be sent to the configured 111 Adapter endpoint.

https://github.com/SRAlexander/nhsd-data-library/tree/main/itk-examples-for-111/04%20-%20safeguarding-itk-request