### PR TITLE
NAID-2571: Update `mockito-core` to `5.15.2`

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'org.apache.xmlbeans:xmlbeans:3.1.0'
     implementation 'com.rabbitmq.jms:rabbitmq-jms:3.4.0'
 
-    testImplementation 'org.mockito:mockito-core:4.4.0'
+    testImplementation 'org.mockito:mockito-core:5.15.2'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'

--- a/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/mapper/QuestionnaireMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/oneoneone/cda/report/mapper/QuestionnaireMapperTest.java
@@ -57,6 +57,7 @@ public class QuestionnaireMapperTest {
         when(pathwaysCase.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseId()).thenReturn(CASE_ID);
         when(pathwaysCase.getPathwayDetails().getPathwayTriageDetails().getPathwayTriageArray(0).getUser()).thenReturn(user);
+        when(user.getSkillSet()).thenReturn(null);
         when(pathwaysCase.getCaseReceiveEnd().toString()).thenReturn(DATE);
         when(pathwayUtil.isSetCaseReceiveEnd(pathwaysCase)).thenReturn(true);
         when(triageLine.getQuestion().getTriageLogicId().getPathwayOrderNo()).thenReturn(ORDER_NUMBER);


### PR DESCRIPTION
## What

* Update `mockito-core` to `5.15.2`
* Update deep mocks in QuestionnaireMapperTest to return null for `user` mock due to changes in the way mocks are handled between versions.

## Why

To ensure dependency are up to date.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation where required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](../CHANGELOG.md) with details of my change in the UNRELEASED section if this change affects end users.
